### PR TITLE
рефактор экрана плагинов и реворк фичи стиля обводки

### DIFF
--- a/TMessagesProj/src/main/java/app/exteraless/appearance/FoldersPreviewCell.java
+++ b/TMessagesProj/src/main/java/app/exteraless/appearance/FoldersPreviewCell.java
@@ -1,256 +1,182 @@
 package app.exteraless.appearance;
 
 import static org.telegram.messenger.AndroidUtilities.dp;
-import static org.telegram.messenger.AndroidUtilities.dpf2;
 
-import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.Paint;
-import android.graphics.Path;
-import android.graphics.PorterDuff;
-import android.graphics.PorterDuffColorFilter;
-import android.graphics.RectF;
-import android.graphics.Region;
-import android.graphics.drawable.Drawable;
-import android.text.TextPaint;
 import android.view.Gravity;
 import android.widget.FrameLayout;
 
-import androidx.core.graphics.ColorUtils;
-
-import org.telegram.messenger.AndroidUtilities;
 import org.telegram.messenger.LocaleController;
 import org.telegram.messenger.R;
 import org.telegram.ui.ActionBar.Theme;
-import org.telegram.ui.Components.Easings;
+import org.telegram.ui.Components.FilterTabsView;
 import org.telegram.ui.Components.LayoutHelper;
-
-import java.util.HashMap;
+import org.telegram.ui.Components.blur3.BlurredBackgroundDrawableViewFactory;
+import org.telegram.ui.Components.blur3.drawable.BlurredBackgroundDrawable;
+import org.telegram.ui.Components.blur3.drawable.color.impl.BlurredBackgroundProviderImpl;
+import org.telegram.ui.Components.blur3.source.BlurredBackgroundSourceColor;
 
 import tw.nekomimi.nekogram.NekoConfig;
-import tw.nekomimi.nekogram.NekoXConfig;
 import xyz.nextalone.nagram.NaConfig;
 
 /**
- * Превью вкладок папок. Порт FoldersPreviewCell из exteraGram 10.10.1.
- * Стиль вкладок фиксирован как стандартный (у NagramX нет стилей табов),
- * поэтому анимация смены стиля опущена, а прогрессы стиля равны 0.
- * Привязки: заголовок/иконки -> NekoConfig.tabsTitleType,
- * счётчик -> NaConfig.ignoreUnreadCount, скрытие «All Chats» -> NekoConfig.hideAllTab.
+ * Live preview of chat folders. It deliberately reuses the same {@link FilterTabsView}
+ * as the chat list, so changes to the real component's shape, spacing and drawing are
+ * reflected here without maintaining a second approximation.
  */
 @SuppressLint("ViewConstructor")
 public class FoldersPreviewCell extends FrameLayout {
 
-    private final FrameLayout preview;
+    private static final int TAB_ALL = 0;
+    private static final int TAB_GROUPS = 1;
+    private static final int TAB_BOTS = 2;
+    private static final int TAB_CHANNELS = 3;
 
-    private final RectF rect = new RectF();
-    private final TextPaint textPaint = new TextPaint(Paint.ANTI_ALIAS_FLAG);
-    private final Paint outlinePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private final Theme.ResourcesProvider resourcesProvider;
+    private final FilterTabsView tabsView;
+    private final BlurredBackgroundSourceColor backgroundSource;
 
-    // Стилевые прогрессы фиксированы (стандартные вкладки).
-    private final float roundedStyleProgress = 0f;
-    private final float chipsStyleProgress = 0f;
-    private final float textStyleProgress = 0f;
-    private final float pillsStyleProgress = 0f;
-
-    private float hideAllChatsProgress = 1f;
-    private float iconProgress = 0f, titleProgress = 1f;
-    private float counterProgress = 1f;
-
-    private ValueAnimator animator;
-
-    private static final HashMap<String, Integer> ICONS = new HashMap<>();
-
-    static {
-        ICONS.put("💬", R.drawable.filter_all);
-        ICONS.put("👥", R.drawable.filter_group);
-        ICONS.put("🤖", R.drawable.filter_bots);
-        ICONS.put("📢", R.drawable.filter_channels);
-        ICONS.put("🔔", R.drawable.filter_unmuted);
-        ICONS.put("🏠", R.drawable.filter_home);
-        ICONS.put("✅", R.drawable.filter_unread);
-        ICONS.put("🎭", R.drawable.filter_mask);
-    }
-
-    private final String[][] filters = new String[][]{
-            {LocaleController.getString(R.string.FilterAllChats), "💬"},
-            {LocaleController.getString(R.string.FilterGroups), "👥"},
-            {LocaleController.getString(R.string.FilterBots), "🤖"},
-            {LocaleController.getString(R.string.FilterChannels), "📢"},
-            {LocaleController.getString(R.string.FilterNameNonMuted), "🔔"},
-            {LocaleController.getString(R.string.FilterContacts), "🏠"},
-            {LocaleController.getString(R.string.FilterNameUnread), "✅"},
-            {LocaleController.getString(R.string.FilterNonContacts), "🎭"},
-    };
-
-    private String allChatsTabName;
-    private String allChatsTabIcon;
-
-    private static int iconRes(String emoji) {
-        Integer res = ICONS.get(emoji);
-        return res != null ? res : R.drawable.filter_all;
-    }
+    private int renderedTitleType = Integer.MIN_VALUE;
 
     public FoldersPreviewCell(Context context) {
+        this(context, null);
+    }
+
+    public FoldersPreviewCell(Context context, Theme.ResourcesProvider resourcesProvider) {
         super(context);
+        this.resourcesProvider = resourcesProvider;
         setWillNotDraw(false);
-        setBackgroundColor(Theme.getColor(Theme.key_windowBackgroundWhite));
+        setClipChildren(false);
 
-        outlinePaint.setStyle(Paint.Style.STROKE);
-        outlinePaint.setColor(ColorUtils.setAlphaComponent(Theme.getColor(Theme.key_switchTrack), 0x3F));
-        outlinePaint.setStrokeWidth(Math.max(2, dp(1f)));
-
-        preview = new FrameLayout(context) {
-            @SuppressLint("DrawAllocation")
+        tabsView = new FilterTabsView(context, resourcesProvider);
+        tabsView.setDelegate(new FilterTabsView.FilterTabsViewDelegate() {
             @Override
-            protected void onDraw(Canvas canvas) {
-                int color = Theme.getColor(Theme.key_switchTrack);
-                int r = Color.red(color);
-                int g = Color.green(color);
-                int b = Color.blue(color);
-                float w = getMeasuredWidth();
-                float h = getMeasuredHeight();
-
-                rect.set(0, 0, w, h);
-                Theme.dialogs_onlineCirclePaint.setColor(Color.argb(20, r, g, b));
-                canvas.drawRoundRect(rect, dp(8), dp(8), Theme.dialogs_onlineCirclePaint);
-
-                float stroke = outlinePaint.getStrokeWidth() / 2;
-                rect.set(stroke, stroke, w - stroke, h - stroke);
-                canvas.drawRoundRect(rect, dp(8), dp(8), outlinePaint);
-
-                float startY = h - dp(4) - dpf2(4.5f * chipsStyleProgress) - stroke;
-
-                Path tab = new Path();
-                tab.addRect(0, startY + dp(4), getMeasuredWidth(), startY + dp(10), Path.Direction.CCW);
-                canvas.save();
-                canvas.clipPath(tab, Region.Op.DIFFERENCE);
-
-                textPaint.setTypeface(AndroidUtilities.getTypeface(AndroidUtilities.TYPEFACE_ROBOTO_MEDIUM));
-
-                float startX = dp(25);
-                for (int i = 0; i < filters.length; i++) {
-                    textPaint.setTextSize(dp(15));
-                    if (i == 0) {
-                        textPaint.setColor(ColorUtils.blendARGB(0x00, Theme.getColor(Theme.key_windowBackgroundWhiteValueText), hideAllChatsProgress));
-                        textPaint.setTextScaleX(hideAllChatsProgress * titleProgress);
-                        Theme.dialogs_onlineCirclePaint.setColor(ColorUtils.blendARGB(Theme.getColor(Theme.key_windowBackgroundWhiteValueText), ColorUtils.setAlphaComponent(Theme.getColor(Theme.key_windowBackgroundWhiteValueText), 0x1F), chipsStyleProgress));
-                        Theme.dialogs_onlineCirclePaint.setColor(ColorUtils.blendARGB(0x00, Theme.dialogs_onlineCirclePaint.getColor(), hideAllChatsProgress));
-                    } else {
-                        textPaint.setColor(ColorUtils.blendARGB(0x00, color, titleProgress));
-                        textPaint.setTextScaleX(titleProgress);
-                    }
-                    String name = i == 0 ? allChatsTabName : filters[i][0];
-                    Drawable icon = context.getDrawable(iconRes(i == 0 ? allChatsTabIcon : filters[i][1])).mutate();
-                    icon.setColorFilter(new PorterDuffColorFilter(ColorUtils.blendARGB(0x00, i == 0 ? textPaint.getColor() : color, iconProgress), PorterDuff.Mode.MULTIPLY));
-                    float sw = textPaint.measureText(name) + dp(30 + 4) * iconProgress + (i == 0 ? dpf2(24) * counterProgress : 1) + 14 * (1 - iconProgress) * titleProgress - dp(4) * iconProgress * (1 - titleProgress) * counterProgress;
-                    if (i == 0) {
-                        canvas.drawRoundRect(
-                                startX,
-                                startY + dpf2(6) * textStyleProgress - dpf2(37.5f) * chipsStyleProgress,
-                                startX + sw + dpf2(4) * (1 - titleProgress) * (1 - counterProgress) + dpf2(22) * chipsStyleProgress,
-                                startY + dp(8) - dpf2(4) * roundedStyleProgress - dpf2(9.5f) * chipsStyleProgress,
-                                dpf2(10 + 15 * pillsStyleProgress),
-                                dpf2(10 + 15 * pillsStyleProgress),
-                                Theme.dialogs_onlineCirclePaint);
-                        float iconOffset = startX + dpf2(6) * (1 - titleProgress) * (1 - counterProgress) + dpf2(11) * chipsStyleProgress;
-                        icon.setBounds((int) (iconOffset), (int) h / 2 - dp(13), (int) (dpf2(26) * iconProgress * hideAllChatsProgress + iconOffset), (int) h / 2 + dp(13));
-                        canvas.drawText(name, startX + dp(30 * iconProgress) + dpf2(10) * chipsStyleProgress + 7f * (1 - iconProgress) * titleProgress, startY - dp(14), textPaint);
-                        textPaint.setTextScaleX(counterProgress);
-                        textPaint.setTextSize(dp(14 * hideAllChatsProgress * counterProgress));
-                        textPaint.setColor(ColorUtils.blendARGB(0x00, Color.argb(20, r, g, b), counterProgress));
-                        Path path = new Path();
-                        textPaint.getTextPath("3", 0, 1, (int) (startX + sw - dpf2(15.5f) + dpf2(12) * chipsStyleProgress - dp(1) * (1 - titleProgress)), (int) (startY - dpf2(15f)), path);
-                        canvas.clipPath(path, Region.Op.DIFFERENCE);
-
-                        textPaint.setColor(ColorUtils.blendARGB(0x00, Theme.getColor(Theme.key_windowBackgroundWhiteValueText), counterProgress * hideAllChatsProgress));
-                        canvas.drawCircle(startX + sw - dpf2(11.5f) + dpf2(12) * chipsStyleProgress - dp(1) * (1 - titleProgress), h / 2, dp(10 * counterProgress * hideAllChatsProgress), textPaint);
-
-                        startX += dp(25) + sw + dpf2(22) * chipsStyleProgress;
-                    } else {
-                        icon.setBounds((int) startX, (int) h / 2 - dp(13), (int) startX + dp(26 * iconProgress), (int) h / 2 + dp(13));
-                        canvas.drawText(name, startX + dp(30) * iconProgress, startY - dp(14), textPaint);
-                        startX += dp(25) + sw + dpf2(5) * chipsStyleProgress;
-                    }
-                    icon.draw(canvas);
-                }
-                canvas.restore();
+            public void onPageSelected(FilterTabsView.Tab tab, boolean forward) {
+                // The preview has no pages, but the real selector animation is useful here.
             }
-        };
-        preview.setWillNotDraw(false);
-        addView(preview, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT, Gravity.TOP | Gravity.CENTER, 21, 15, 21, 21));
-        updateTabIcons(false);
-        updateTabTitle(false);
-        updateAllChatsTabName(false);
-        updateTabCounter(false);
+
+            @Override
+            public void onPageScrolled(float progress) {
+            }
+
+            @Override
+            public void onSamePageSelected() {
+            }
+
+            @Override
+            public int getTabCounter(int tabId) {
+                if (NaConfig.INSTANCE.getIgnoreUnreadCount().Int() == NekoConfig.DIALOG_FILTER_EXCLUDE_ALL) {
+                    return 0;
+                }
+                return tabId == (NekoConfig.hideAllTab.Bool() ? TAB_GROUPS : TAB_ALL) ? 3 : 0;
+            }
+
+            @Override
+            public boolean didSelectTab(FilterTabsView.TabView tabView, boolean selected) {
+                return false;
+            }
+
+            @Override
+            public boolean isTabMenuVisible() {
+                return false;
+            }
+
+            @Override
+            public void onDeletePressed(int id) {
+            }
+
+            @Override
+            public void onPageReorder(int fromId, int toId) {
+            }
+
+            @Override
+            public boolean canPerformActions() {
+                return false;
+            }
+        });
+        tabsView.setHorizontalScrollingEnabled(false);
+
+        // Match the component setup in DialogsActivity. Only the obsolete preview
+        // frame is omitted: the cell itself remains transparent and blends into its row.
+        backgroundSource = new BlurredBackgroundSourceColor();
+        backgroundSource.setColor(Theme.getColor(Theme.key_windowBackgroundWhite, resourcesProvider));
+        BlurredBackgroundDrawable background = new BlurredBackgroundDrawableViewFactory(backgroundSource)
+                .create(tabsView, BlurredBackgroundProviderImpl.topPanel(resourcesProvider));
+        background.setRadius(dp(18));
+        background.setPadding(dp(6.666f));
+        tabsView.setPadding(0, dp(7), 0, dp(7));
+        tabsView.setBlurredBackground(background);
+
+        addView(tabsView, LayoutHelper.createFrame(
+                LayoutHelper.MATCH_PARENT, 50, Gravity.CENTER, 21, 0, 21, 0));
+        rebuildTabs(false);
+    }
+
+    private void rebuildTabs(boolean animated) {
+        renderedTitleType = NekoConfig.tabsTitleType.Int();
+        tabsView.showAllChatsTab = !NekoConfig.hideAllTab.Bool();
+        tabsView.removeTabs();
+        tabsView.resetTabId();
+
+        if (tabsView.showAllChatsTab) {
+            tabsView.addTab(TAB_ALL, TAB_ALL, LocaleController.getString(R.string.FilterAllChats),
+                    "\uD83D\uDCAC", null, false, true, false);
+        }
+        tabsView.addTab(TAB_GROUPS, TAB_GROUPS, LocaleController.getString(R.string.FilterGroups),
+                "\uD83D\uDC65", null, false, false, false);
+        tabsView.addTab(TAB_BOTS, TAB_BOTS, LocaleController.getString(R.string.FilterBots),
+                "\uD83E\uDD16", null, false, false, false);
+        tabsView.addTab(TAB_CHANNELS, TAB_CHANNELS, LocaleController.getString(R.string.FilterChannels),
+                "\uD83D\uDCE2", null, false, false, false);
+        tabsView.finishAddingTabs(animated);
+        tabsView.requestLayout();
     }
 
     public void updateAllChatsTabName(boolean animate) {
-        // hideAllTab меняет имя первой вкладки: All Chats -> Unread
-        allChatsTabName = NekoConfig.hideAllTab.Bool() ? filters[6][0] : filters[0][0];
-        allChatsTabIcon = NekoConfig.hideAllTab.Bool() ? filters[6][1] : filters[0][1];
-        hideAllChatsProgress = 1f;
-        invalidate();
+        rebuildTabs(animate);
     }
 
     public void updateTabTitle(boolean animate) {
-        // Заголовок скрыт только в режиме «только иконки».
-        float to = NekoConfig.tabsTitleType.Int() != NekoXConfig.TITLE_TYPE_ICON ? 1 : 0;
-        animateFloat(animate, titleProgress, to, v -> titleProgress = v);
+        if (renderedTitleType != NekoConfig.tabsTitleType.Int()) {
+            rebuildTabs(animate);
+        }
     }
 
     public void updateTabIcons(boolean animate) {
-        // Иконки показаны во всех режимах, кроме «только текст».
-        float to = NekoConfig.tabsTitleType.Int() != NekoXConfig.TITLE_TYPE_TEXT ? 1 : 0;
-        animateFloat(animate, iconProgress, to, v -> iconProgress = v);
+        if (renderedTitleType != NekoConfig.tabsTitleType.Int()) {
+            rebuildTabs(animate);
+        }
     }
 
     public void updateTabCounter(boolean animate) {
-        float to = NaConfig.INSTANCE.getIgnoreUnreadCount().Int() != NekoConfig.DIALOG_FILTER_EXCLUDE_ALL ? 1 : 0;
-        animateFloat(animate, counterProgress, to, v -> counterProgress = v);
-    }
-
-    private interface FloatSetter {
-        void set(float v);
-    }
-
-    private void animateFloat(boolean animate, float from, float to, FloatSetter setter) {
-        if (to == from && animate) {
-            return;
-        }
-        if (animate) {
-            animator = ValueAnimator.ofFloat(from, to).setDuration(250);
-            animator.setInterpolator(Easings.easeInOutQuad);
-            animator.addUpdateListener(animation -> {
-                setter.set((Float) animation.getAnimatedValue());
-                invalidate();
-            });
-            animator.start();
-        } else {
-            setter.set(to);
-            invalidate();
-        }
+        tabsView.checkTabsCounter();
     }
 
     @Override
     public void invalidate() {
         super.invalidate();
-        if (preview != null) {
-            preview.invalidate();
+        if (backgroundSource != null) {
+            backgroundSource.setColor(Theme.getColor(Theme.key_windowBackgroundWhite, resourcesProvider));
+        }
+        if (tabsView != null) {
+            tabsView.updateColors();
         }
     }
 
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-        canvas.drawLine(LocaleController.isRTL ? 0 : dp(21), getMeasuredHeight() - 1, getMeasuredWidth() - (LocaleController.isRTL ? dp(21) : 0), getMeasuredHeight() - 1, Theme.dividerPaint);
+        canvas.drawLine(LocaleController.isRTL ? 0 : dp(21), getMeasuredHeight() - 1,
+                getMeasuredWidth() - (LocaleController.isRTL ? dp(21) : 0), getMeasuredHeight() - 1,
+                Theme.dividerPaint);
     }
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        super.onMeasure(MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.EXACTLY), MeasureSpec.makeMeasureSpec(dp(86), MeasureSpec.EXACTLY));
+        super.onMeasure(
+                MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(dp(86), MeasureSpec.EXACTLY));
     }
 }

--- a/TMessagesProj/src/main/java/app/exteraless/plugins/ui/PluginCell.java
+++ b/TMessagesProj/src/main/java/app/exteraless/plugins/ui/PluginCell.java
@@ -19,7 +19,11 @@ import org.telegram.messenger.R;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.BackupImageView;
 import org.telegram.ui.Components.LayoutHelper;
+import org.telegram.ui.Components.RecyclerListView;
 import org.telegram.ui.Components.Switch;
+import org.telegram.ui.Components.UItem;
+import org.telegram.ui.Components.UniversalAdapter;
+import org.telegram.ui.Components.UniversalRecyclerView;
 
 import app.exteraless.plugins.Plugin;
 import app.exteraless.plugins.PluginsController;
@@ -67,9 +71,93 @@ public class PluginCell extends FrameLayout {
     private final ImageView deleteButton;
     private final Switch switchView;
 
-    private Plugin plugin;
+    private String pluginId;
+    private String pluginIcon;
     private Delegate delegate;
     private boolean compact;
+
+    static final class Model {
+        final Plugin plugin;
+        final String id;
+        final String name;
+        final String subtitle;
+        final String description;
+        final String loadError;
+        final String icon;
+        final boolean enabled;
+        final boolean hasSettings;
+        final boolean pinned;
+        final boolean compact;
+
+        Model(Plugin plugin, boolean pinned, boolean compact) {
+            this.plugin = plugin;
+            id = plugin.id;
+            name = plugin.getDisplayName();
+            subtitle = plugin.getSubtitle();
+            description = plugin.description;
+            loadError = plugin.loadError;
+            icon = plugin.icon;
+            enabled = plugin.enabled;
+            hasSettings = plugin.hasSettings;
+            this.pinned = pinned;
+            this.compact = compact;
+        }
+
+        boolean sameContent(Model other) {
+            return other != null
+                    && TextUtils.equals(name, other.name)
+                    && TextUtils.equals(subtitle, other.subtitle)
+                    && TextUtils.equals(description, other.description)
+                    && TextUtils.equals(loadError, other.loadError)
+                    && TextUtils.equals(icon, other.icon)
+                    && enabled == other.enabled
+                    && hasSettings == other.hasSettings
+                    && pinned == other.pinned
+                    && compact == other.compact;
+        }
+    }
+
+    public static final class Factory extends UItem.UItemFactory<PluginCell> {
+        static {
+            setup(new Factory());
+        }
+
+        @Override
+        public PluginCell createView(Context context, RecyclerListView listView, int currentAccount,
+                                     int classGuid, Theme.ResourcesProvider resourcesProvider) {
+            return new PluginCell(context);
+        }
+
+        @Override
+        public void bindView(View view, UItem item, boolean divider, UniversalAdapter adapter,
+                             UniversalRecyclerView listView) {
+            PluginCell cell = (PluginCell) view;
+            cell.setDelegate((Delegate) item.object2);
+            cell.setModel((Model) item.object);
+        }
+
+        @Override
+        public boolean equals(UItem first, UItem second) {
+            Model a = first.object instanceof Model ? (Model) first.object : null;
+            Model b = second.object instanceof Model ? (Model) second.object : null;
+            return a != null && b != null && TextUtils.equals(a.id, b.id);
+        }
+
+        @Override
+        public boolean contentsEquals(UItem first, UItem second) {
+            Model a = first.object instanceof Model ? (Model) first.object : null;
+            Model b = second.object instanceof Model ? (Model) second.object : null;
+            return a != null && a.sameContent(b);
+        }
+
+        static UItem of(Plugin plugin, boolean pinned, boolean compact, Delegate delegate) {
+            UItem item = UItem.ofFactory(Factory.class);
+            item.object = new Model(plugin, pinned, compact);
+            item.object2 = delegate;
+            item.transparent = true;
+            return item;
+        }
+    }
 
     public PluginCell(Context context) {
         super(context);
@@ -79,7 +167,7 @@ public class PluginCell extends FrameLayout {
         // высокая карточка превращалась в «таблетку» с полукруглыми боками.
         card = new View(context);
         addView(card, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT,
-                Gravity.FILL, 8, 0, 8, 8));
+                Gravity.FILL, 12, 0, 12, 8));
 
         LinearLayout root = new LinearLayout(context);
         root.setOrientation(LinearLayout.VERTICAL);
@@ -187,7 +275,11 @@ public class PluginCell extends FrameLayout {
     private enum Action { TOGGLE, SHARE, PIN, SETTINGS, PERMISSIONS, DELETE }
 
     private void callDelegate(Action action) {
-        if (delegate == null || plugin == null) {
+        if (delegate == null || pluginId == null) {
+            return;
+        }
+        Plugin plugin = PluginsController.getInstance().getPlugin(pluginId);
+        if (plugin == null) {
             return;
         }
         switch (action) {
@@ -247,30 +339,38 @@ public class PluginCell extends FrameLayout {
         this.delegate = delegate;
     }
 
-    public void setPlugin(Plugin plugin, boolean compact) {
-        this.plugin = plugin;
-        this.compact = compact;
-        if (plugin == null) {
+    private void setModel(Model model) {
+        if (model == null || model.plugin == null) {
+            pluginId = null;
+            pluginIcon = null;
             return;
         }
-        PluginsController controller = PluginsController.getInstance();
+        boolean updateIcon = !TextUtils.equals(pluginId, model.id)
+                || !TextUtils.equals(pluginIcon, model.icon);
+        pluginId = model.id;
+        pluginIcon = model.icon;
+        compact = model.compact;
 
-        imageView.setVisibility(GONE);
-        PluginIcons.apply(imageView, plugin, this::requestLayout);
+        if (updateIcon) {
+            imageView.setTag(null);
+            imageView.setImageDrawable(null);
+            imageView.setVisibility(GONE);
+            PluginIcons.apply(imageView, model.plugin, this::requestLayout);
+        }
 
-        nameView.setText(plugin.getDisplayName());
-        subtitleView.setText(plugin.getSubtitle());
+        nameView.setText(model.name);
+        subtitleView.setText(model.subtitle);
 
-        if (plugin.loadError != null) {
+        if (model.loadError != null) {
             // Ошибка вытесняет описание: если плагин не поднялся, всё остальное
             // про него сейчас неважно.
-            descriptionView.setText(plugin.loadError);
+            descriptionView.setText(model.loadError);
             descriptionView.setTextColor(Theme.getColor(Theme.key_text_RedRegular));
             descriptionView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 12);
             descriptionView.setTypeface(AndroidUtilities.getTypeface("fonts/rmono.ttf"));
             descriptionView.setVisibility(VISIBLE);
-        } else if (!TextUtils.isEmpty(plugin.description)) {
-            descriptionView.setText(plugin.description);
+        } else if (!TextUtils.isEmpty(model.description)) {
+            descriptionView.setText(model.description);
             descriptionView.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteBlackText));
             descriptionView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 15);
             descriptionView.setTypeface(android.graphics.Typeface.DEFAULT);
@@ -279,10 +379,10 @@ public class PluginCell extends FrameLayout {
             descriptionView.setVisibility(GONE);
         }
 
-        pinButton.setImageResource(controller.isPluginPinned(plugin.id)
+        pinButton.setImageResource(model.pinned
                 ? R.drawable.msg_unpin : R.drawable.msg_pin);
-        settingsButton.setVisibility(plugin.enabled && plugin.hasSettings ? VISIBLE : GONE);
-        switchView.setChecked(plugin.enabled, false);
+        settingsButton.setVisibility(model.enabled && model.hasSettings ? VISIBLE : GONE);
+        switchView.setChecked(model.enabled, false);
 
         updateLayout();
     }

--- a/TMessagesProj/src/main/java/app/exteraless/plugins/ui/PluginUiItem.java
+++ b/TMessagesProj/src/main/java/app/exteraless/plugins/ui/PluginUiItem.java
@@ -1,0 +1,114 @@
+package app.exteraless.plugins.ui;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.view.View;
+
+import org.telegram.messenger.AndroidUtilities;
+import org.telegram.ui.ActionBar.Theme;
+import org.telegram.ui.Cells.TextCheckCell;
+import org.telegram.ui.Components.ListView.AdapterWithDiffUtils;
+import org.telegram.ui.Components.RecyclerListView;
+import org.telegram.ui.Components.UItem;
+import org.telegram.ui.Components.UniversalAdapter;
+import org.telegram.ui.Components.UniversalRecyclerView;
+
+final class PluginUiItem extends UItem {
+
+    private PluginUiItem(int viewType) {
+        super(viewType, false);
+    }
+
+    static PluginUiItem check(int id, CharSequence text, int iconResId) {
+        PluginUiItem item = new PluginUiItem(UniversalAdapter.VIEW_TYPE_CHECK);
+        item.id = id;
+        item.text = text;
+        item.iconResId = iconResId;
+        return item;
+    }
+
+    static UItem engineToggle(int id, CharSequence text, boolean checked) {
+        return EngineToggleFactory.of(id, text, checked);
+    }
+
+    static PluginUiItem fullscreen(View view, int minusHeight, boolean minusPadding) {
+        PluginUiItem item = new PluginUiItem(UniversalAdapter.VIEW_TYPE_FULLSCREEN_CUSTOM);
+        item.view = view;
+        item.intValue = minusHeight;
+        item.flags = minusPadding ? 1 : 0;
+        item.transparent = true;
+        return item;
+    }
+
+    @Override
+    protected boolean contentsEquals(AdapterWithDiffUtils.Item candidate) {
+        if (!(candidate instanceof PluginUiItem)) {
+            return false;
+        }
+        PluginUiItem item = (PluginUiItem) candidate;
+        if (viewType != item.viewType || id != item.id || enabled != item.enabled) {
+            return false;
+        }
+        if (viewType == UniversalAdapter.VIEW_TYPE_CHECK) {
+            return checked == item.checked
+                    && iconResId == item.iconResId
+                    && multiline == item.multiline
+                    && TextUtils.equals(text, item.text)
+                    && TextUtils.equals(textValue, item.textValue);
+        }
+        if (viewType == UniversalAdapter.VIEW_TYPE_FULLSCREEN_CUSTOM) {
+            return view == item.view
+                    && intValue == item.intValue
+                    && flags == item.flags
+                    && transparent == item.transparent;
+        }
+        return super.contentsEquals(candidate);
+    }
+
+    private static final class EngineToggleFactory extends UItem.UItemFactory<TextCheckCell> {
+        static {
+            setup(new EngineToggleFactory());
+        }
+
+        @Override
+        public TextCheckCell createView(Context context, RecyclerListView listView,
+                                        int currentAccount, int classGuid,
+                                        Theme.ResourcesProvider resourcesProvider) {
+            TextCheckCell cell = new TextCheckCell(context, resourcesProvider);
+            cell.setDrawCheckRipple(true);
+            cell.setTypeface(AndroidUtilities.bold());
+            cell.setHeight(56);
+            return cell;
+        }
+
+        @Override
+        public void bindView(View view, UItem item, boolean divider, UniversalAdapter adapter,
+                             UniversalRecyclerView listView) {
+            TextCheckCell cell = (TextCheckCell) view;
+            cell.setEnabled(item.enabled, null);
+            cell.setIcon(0);
+            cell.setTextAndCheck(item.text, item.checked, divider);
+        }
+
+        @Override
+        public boolean equals(UItem first, UItem second) {
+            return first.id == second.id;
+        }
+
+        @Override
+        public boolean contentsEquals(UItem first, UItem second) {
+            return first.id == second.id
+                    && first.checked == second.checked
+                    && first.enabled == second.enabled
+                    && TextUtils.equals(first.text, second.text);
+        }
+
+        static UItem of(int id, CharSequence text, boolean checked) {
+            UItem item = UItem.ofFactory(EngineToggleFactory.class);
+            item.id = id;
+            item.text = text;
+            item.checked = checked;
+            return item;
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/plugins/ui/PluginsActivity.java
+++ b/TMessagesProj/src/main/java/app/exteraless/plugins/ui/PluginsActivity.java
@@ -4,18 +4,15 @@ import static org.telegram.messenger.AndroidUtilities.dp;
 import static org.telegram.messenger.LocaleController.getString;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.ClickableSpan;
-import android.view.Gravity;
 import android.view.View;
 import android.widget.FrameLayout;
-import android.widget.LinearLayout;
-
-import android.content.Context;
 
 import org.telegram.messenger.AndroidUtilities;
 import org.telegram.ui.Components.BulletinFactory;
@@ -28,7 +25,6 @@ import org.telegram.ui.ActionBar.AlertDialog;
 import org.telegram.ui.ActionBar.BaseFragment;
 import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.LayoutHelper;
-import org.telegram.ui.Components.LinkSpanDrawable;
 import org.telegram.ui.Components.UItem;
 import org.telegram.ui.Components.UniversalAdapter;
 import org.telegram.ui.Components.UniversalRecyclerView;
@@ -65,22 +61,16 @@ public class PluginsActivity extends BaseFragment {
     private static final int MENU_INFO = 1;
 
     private static final int ID_ENGINE_TOGGLE = -1;
-    /** id строк плагинов начинаются отсюда — не пересекаются со служебными. */
-    private static final int ID_PLUGIN_BASE = 1000;
 
     private static final int REQUEST_CODE_PICK_PLUGIN = 9781;
 
     private UniversalRecyclerView listView;
     private final List<Plugin> plugins = new ArrayList<>();
-    /** Вьюхи карточек по id плагина: см. {@link #cellFor}. */
-    private final java.util.HashMap<String, PluginCell> cells = new java.util.HashMap<>();
+    private PluginsEmptyCell emptyCell;
     private String searchQuery;
 
     @Override
     public View createView(Context context) {
-        // Пересоздание вьюхи фрагмента бывает при смене темы: карточки забрали
-        // цвета при постройке, поэтому старые больше не годятся.
-        cells.clear();
         actionBar.setBackButtonImage(R.drawable.ic_ab_back);
         actionBar.setAllowOverlayTitle(true);
         actionBar.setTitle(getString(R.string.OpenExteraPlugins));
@@ -103,13 +93,13 @@ public class PluginsActivity extends BaseFragment {
                                     @Override
                                     public void onSearchCollapse() {
                                         searchQuery = null;
-                                        update();
+                                        updateRows();
                                     }
 
                                     @Override
                                     public void onTextChanged(android.widget.EditText editText) {
                                         searchQuery = editText.getText().toString();
-                                        update();
+                                        updateRows();
                                     }
                                 });
         search.setSearchFieldHint(getString(R.string.Search));
@@ -118,8 +108,16 @@ public class PluginsActivity extends BaseFragment {
         FrameLayout contentView = new FrameLayout(context);
         contentView.setBackgroundColor(Theme.getColor(Theme.key_windowBackgroundGray));
 
+        refreshPlugins(true);
+        emptyCell = new PluginsEmptyCell(context, getCurrentAccount());
         listView = new UniversalRecyclerView(this, this::fillItems, this::onItemClick,
-                this::onItemLongClick);
+                this::onItemLongClick) {
+            @Override
+            protected boolean canHighlightChildAt(View child, float x, float y) {
+                return !(child instanceof PluginCell)
+                        && super.canHighlightChildAt(child, x, y);
+            }
+        };
         listView.setSections();
         listView.adapter.setApplyBackground(false);
         contentView.addView(listView,
@@ -132,9 +130,9 @@ public class PluginsActivity extends BaseFragment {
 
     // ---------- список ----------
 
-    private void reloadPlugins() {
+    private void refreshPlugins(boolean rescan) {
         PluginsController controller = PluginsController.getInstance();
-        if (controller.isEngineEnabled()) {
+        if (rescan && controller.isEngineEnabled()) {
             // Движок стартует асинхронно; rescan сам выйдет, если он ещё не поднялся.
             controller.rescanPlugins();
         }
@@ -168,71 +166,30 @@ public class PluginsActivity extends BaseFragment {
     }
 
     private void fillItems(ArrayList<UItem> items, UniversalAdapter adapter) {
-        reloadPlugins();
         PluginsController controller = PluginsController.getInstance();
+        boolean engineEnabled = controller.isEngineEnabled();
 
-        items.add(UItem.asRippleCheck(ID_ENGINE_TOGGLE, getString(R.string.EnablePluginsEngine))
-                .setChecked(controller.isEngineEnabled()));
+        items.add(PluginUiItem.engineToggle(ID_ENGINE_TOGGLE,
+                getString(R.string.EnablePluginsEngine), engineEnabled));
+        if (!engineEnabled) {
+            return;
+        }
         items.add(UItem.asSpace(dp(8)));
 
         List<Plugin> visible = visiblePlugins();
         if (visible.isEmpty()) {
-            items.add(UItem.asFullscreenCustom(createEmptyView(), dp(74), true).setTransparent(true));
+            CharSequence hint = TextUtils.isEmpty(searchQuery)
+                    ? withUsernameLink(getString(R.string.PluginsEmptyHint))
+                    : getString(R.string.PluginsNotFound);
+            emptyCell.setState(engineEnabled, hint, listView != null);
+            items.add(PluginUiItem.fullscreen(emptyCell, dp(74), true));
             return;
         }
-        for (int i = 0; i < visible.size(); i++) {
-            Plugin plugin = visible.get(i);
-            PluginCell cell = cellFor(plugin);
-            // Прозрачным: фон карточка рисует сама, иначе поверх неё ложится
-            // ещё и плашка секции — с другим скруглением.
-            items.add(UItem.asCustom(ID_PLUGIN_BASE + i, cell).setTransparent(true));
+        boolean compact = controller.isCompactView();
+        for (Plugin plugin : visible) {
+            items.add(PluginCell.Factory.of(plugin, controller.isPluginPinned(plugin.id),
+                    compact, cellDelegate));
         }
-    }
-
-    /**
-     * Одна и та же вьюха на плагин между пересборками списка.
-     *
-     * UItem считает элементы разными, если у них разные view (UItem.itemEquals:
-     * {@code view == item.view}), — на новую вьюху каждый раз DiffUtil отвечал
-     * «строку удалили и вставили другую», и RecyclerView проигрывал анимацию
-     * удаления с вставкой. Со стороны это выглядело как «карточка дёрнулась по
-     * высоте и вернулась» на каждое действие: вход на экран, включение плагина.
-     */
-    private PluginCell cellFor(Plugin plugin) {
-        PluginCell cell = cells.get(plugin.id);
-        if (cell == null) {
-            cell = new PluginCell(getContext());
-            cell.setDelegate(cellDelegate);
-            cells.put(plugin.id, cell);
-        }
-        cell.setPlugin(plugin, PluginsController.getInstance().isCompactView());
-        return cell;
-    }
-
-    private View createEmptyView() {
-        Context context = getContext();
-        LinearLayout layout = new LinearLayout(context);
-        layout.setOrientation(LinearLayout.VERTICAL);
-        layout.setGravity(Gravity.CENTER);
-
-        android.widget.TextView emoji = new android.widget.TextView(context);
-        emoji.setText("📁");
-        emoji.setTextSize(android.util.TypedValue.COMPLEX_UNIT_DIP, 48);
-        emoji.setGravity(Gravity.CENTER);
-        layout.addView(emoji, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT,
-                LayoutHelper.WRAP_CONTENT, Gravity.CENTER, 0, 0, 0, 12));
-
-        LinkSpanDrawable.LinksTextView hint = new LinkSpanDrawable.LinksTextView(context);
-        hint.setTextSize(android.util.TypedValue.COMPLEX_UNIT_DIP, 14);
-        hint.setGravity(Gravity.CENTER);
-        hint.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteGrayText));
-        hint.setLinkTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteBlueText));
-        hint.setText(TextUtils.isEmpty(searchQuery)
-                ? withUsernameLink(getString(R.string.PluginsEmptyHint))
-                : getString(R.string.PluginsNotFound));
-        layout.addView(hint, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT,
-                LayoutHelper.WRAP_CONTENT, Gravity.CENTER, 24, 0, 24, 0));
-        return layout;
     }
 
     /**
@@ -284,7 +241,8 @@ public class PluginsActivity extends BaseFragment {
             PluginsController controller = PluginsController.getInstance();
             boolean pinned = !controller.isPluginPinned(plugin.id);
             controller.setPluginPinned(plugin.id, pinned);
-            update();
+            refreshPlugins(false);
+            updateRows();
             if (getContext() != null) {
                 org.telegram.ui.Components.BulletinFactory.of(PluginsActivity.this)
                         .createSimpleBulletin(pinned ? R.raw.ic_pin : R.raw.ic_unpin,
@@ -368,7 +326,7 @@ public class PluginsActivity extends BaseFragment {
         controller.setPluginEnabled(plugin.id, !plugin.enabled);
         Plugin updated = controller.getPlugin(plugin.id);
         boolean enabled = updated != null && updated.enabled;
-        update();
+        updateRows();
         if (enabled && updated.loadError != null) {
             // Плагин уже падал: покажем, на чём именно, иначе включение
             // выглядит как «щёлкнул и ничего».
@@ -376,7 +334,7 @@ public class PluginsActivity extends BaseFragment {
         }
     }
 
-    private void update() {
+    private void updateRows() {
         if (listView != null) {
             listView.adapter.update(true);
         }
@@ -389,7 +347,7 @@ public class PluginsActivity extends BaseFragment {
         if (item.id == ID_ENGINE_TOGGLE) {
             boolean enabling = !controller.isEngineEnabled();
             controller.setEngineEnabled(enabling);
-            update();
+            updateRows();
             if (enabling) {
                 // Python поднимается асинхронно (около 240 мс на Pixel 7), а
                 // rescanPlugins до его старта выходит рано. Без обновления по
@@ -399,7 +357,8 @@ public class PluginsActivity extends BaseFragment {
                         org.telegram.messenger.ApplicationLoader.applicationContext,
                         ok -> AndroidUtilities.runOnUIThread(() -> {
                             if (getParentActivity() != null) {
-                                update();
+                                refreshPlugins(true);
+                                updateRows();
                             }
                         }));
             }
@@ -421,9 +380,11 @@ public class PluginsActivity extends BaseFragment {
     }
 
     private Plugin pluginOf(UItem item) {
-        int index = item.id - ID_PLUGIN_BASE;
-        List<Plugin> visible = visiblePlugins();
-        return index >= 0 && index < visible.size() ? visible.get(index) : null;
+        if (!(item.object instanceof PluginCell.Model)) {
+            return null;
+        }
+        String id = ((PluginCell.Model) item.object).id;
+        return PluginsController.getInstance().getPlugin(id);
     }
 
     // ---------- диалоги ----------
@@ -498,7 +459,8 @@ public class PluginsActivity extends BaseFragment {
                 presentFragment(PluginSettingsActivity.newInstance(plugin.id));
             } else if (action == 1) {
                 controller.reloadPlugin(plugin.id);
-                update();
+                refreshPlugins(false);
+                updateRows();
             } else if (action == 2) {
                 AndroidUtilities.addToClipboard(plugin.id);
             } else if (action == 3) {
@@ -523,8 +485,8 @@ public class PluginsActivity extends BaseFragment {
                 plugin.getDisplayName()));
         builder.setPositiveButton(getString(R.string.Delete), (dialog, which) -> {
             PluginsController.getInstance().uninstallPlugin(plugin.id);
-            cells.remove(plugin.id);
-            update();
+            refreshPlugins(false);
+            updateRows();
         });
         builder.setNegativeButton(getString(R.string.Cancel), null);
         AlertDialog dialog = builder.create();
@@ -634,6 +596,20 @@ public class PluginsActivity extends BaseFragment {
                     .setPositiveButton(getString(R.string.OK), null)
                     .create());
         }
-        update();
+        refreshPlugins(true);
+        updateRows();
+    }
+
+    @Override
+    public boolean isSupportEdgeToEdge() {
+        return true;
+    }
+
+    @Override
+    public void onInsets(int left, int top, int right, int bottom) {
+        if (listView != null) {
+            listView.setPadding(0, 0, 0, bottom);
+            listView.setClipToPadding(false);
+        }
     }
 }

--- a/TMessagesProj/src/main/java/app/exteraless/plugins/ui/PluginsEmptyCell.java
+++ b/TMessagesProj/src/main/java/app/exteraless/plugins/ui/PluginsEmptyCell.java
@@ -1,0 +1,121 @@
+package app.exteraless.plugins.ui;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+
+import org.telegram.ui.ActionBar.Theme;
+import org.telegram.ui.Components.LayoutHelper;
+import org.telegram.ui.Components.LinkSpanDrawable;
+import org.telegram.ui.Components.StickerImageView;
+
+final class PluginsEmptyCell extends FrameLayout {
+
+    private static final String EMPTY_STICKER_PACK = "AnimatedEmojies";
+    private static final int EMPTY_STICKER_INDEX = 47;
+
+    private final LinearLayout content;
+    private final LinkSpanDrawable.LinksTextView hintView;
+
+    private boolean initialized;
+    private boolean contentVisible;
+    private int animationGeneration;
+
+    PluginsEmptyCell(Context context, int currentAccount) {
+        super(context);
+        setClipChildren(false);
+        setClipToPadding(false);
+
+        content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setGravity(Gravity.CENTER);
+        addView(content, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT,
+                LayoutHelper.WRAP_CONTENT, Gravity.CENTER));
+
+        StickerImageView stickerView = new StickerImageView(context, currentAccount);
+        stickerView.setAspectFit(true);
+        stickerView.setStickerPackName(EMPTY_STICKER_PACK);
+        stickerView.setStickerNum(EMPTY_STICKER_INDEX);
+        content.addView(stickerView, LayoutHelper.createLinear(130, 130, Gravity.CENTER,
+                0, 0, 0, 16));
+
+        hintView = new LinkSpanDrawable.LinksTextView(context);
+        hintView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14);
+        hintView.setGravity(Gravity.CENTER);
+        hintView.setTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteGrayText));
+        hintView.setLinkTextColor(Theme.getColor(Theme.key_windowBackgroundWhiteBlueText));
+        content.addView(hintView, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT,
+                LayoutHelper.WRAP_CONTENT, Gravity.CENTER, 24, 0, 24, 0));
+    }
+
+    void setState(boolean visible, CharSequence text, boolean animated) {
+        boolean textChanged = !TextUtils.equals(hintView.getText(), text);
+        if (initialized && visible == contentVisible) {
+            if (!textChanged) {
+                return;
+            }
+            if (!visible) {
+                hintView.setText(text);
+                return;
+            }
+        }
+        int generation = ++animationGeneration;
+        content.animate().setListener(null).cancel();
+
+        if (!initialized || !animated || !isAttachedToWindow()) {
+            hintView.setText(text);
+            contentVisible = visible;
+            initialized = true;
+            content.setAlpha(visible ? 1f : 0f);
+            content.setVisibility(visible ? VISIBLE : INVISIBLE);
+            content.setEnabled(visible);
+            hintView.setEnabled(visible);
+            return;
+        }
+
+        initialized = true;
+        content.setEnabled(visible);
+        hintView.setEnabled(visible);
+
+        if (textChanged && visible && contentVisible) {
+            content.animate()
+                    .alpha(0f)
+                    .setDuration(90)
+                    .withEndAction(() -> {
+                        if (generation != animationGeneration) {
+                            return;
+                        }
+                        hintView.setText(text);
+                        content.animate()
+                                .alpha(1f)
+                                .setDuration(150)
+                                .withEndAction(null)
+                                .start();
+                    })
+                    .start();
+        } else {
+            if (textChanged) {
+                hintView.setText(text);
+            }
+            content.setVisibility(VISIBLE);
+            content.animate()
+                    .alpha(visible ? 1f : 0f)
+                    .setDuration(180)
+                    .withEndAction(() -> {
+                        if (generation == animationGeneration && !visible) {
+                            content.setVisibility(INVISIBLE);
+                        }
+                    })
+                    .start();
+        }
+        contentVisible = visible;
+    }
+
+    @Override
+    public boolean hasOverlappingRendering() {
+        return false;
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/plugins/ui/PluginsInfoActivity.java
+++ b/TMessagesProj/src/main/java/app/exteraless/plugins/ui/PluginsInfoActivity.java
@@ -6,9 +6,7 @@ import android.content.Context;
 import android.view.View;
 import android.widget.FrameLayout;
 
-import org.telegram.messenger.AndroidUtilities;
 import org.telegram.messenger.FileLog;
-import org.telegram.messenger.LocaleController;
 import org.telegram.messenger.R;
 import org.telegram.messenger.browser.Browser;
 import org.telegram.ui.ActionBar.ActionBar;
@@ -54,7 +52,7 @@ public class PluginsInfoActivity extends BaseFragment {
     private static final int ID_TRUSTED = 8;
 
     private static final String DOCS_URL = "https://plugins.exteragram.app";
-    private static final String TRUSTED_URL = "https://plugins.exteragram.app/trusted";
+    private static final String TRUSTED_URL = "https://t.me/addlist/pPhOtEq00KhjYTc6";
 
     private UniversalRecyclerView listView;
 
@@ -92,21 +90,24 @@ public class PluginsInfoActivity extends BaseFragment {
         boolean safeMode = controller.isSafeMode();
 
         items.add(UItem.asHeader(getString(R.string.Settings)));
-        items.add(UItem.asCheck(ID_DEVELOPER_MODE, getString(R.string.PluginsDeveloperMode),
+        items.add(PluginUiItem.check(ID_DEVELOPER_MODE,
+                        getString(R.string.PluginsDeveloperMode),
                         R.drawable.msg_settings)
                 .setChecked(controller.isDeveloperMode())
                 .setEnabled(engineOn && !safeMode));
-        items.add(UItem.asCheck(ID_COMPACT_VIEW, getString(R.string.PluginsCompactView),
+        items.add(PluginUiItem.check(ID_COMPACT_VIEW,
+                        getString(R.string.PluginsCompactView),
                         R.drawable.msg_topics)
                 .setChecked(controller.isCompactView())
                 .setEnabled(engineOn));
-        items.add(UItem.asCheck(ID_COMPATIBILITY, getString(R.string.PluginsCompatibilityMode),
+        items.add(PluginUiItem.check(ID_COMPATIBILITY,
+                        getString(R.string.PluginsCompatibilityMode),
                         R.drawable.msg_link2)
                 .setChecked(controller.isCompatibilityMode())
                 .setValue(getString(R.string.PluginsCompatibilityModeInfo))
                 .setMultiline(true)
                 .setEnabled(engineOn));
-        items.add(UItem.asCheck(ID_SAFE_MODE, getString(R.string.PluginsSafeMode),
+        items.add(PluginUiItem.check(ID_SAFE_MODE, getString(R.string.PluginsSafeMode),
                         R.drawable.msg_secret)
                 .setChecked(safeMode));
         items.add(UItem.asShadow(getString(R.string.PluginsSafeModeSummary)));
@@ -129,6 +130,9 @@ public class PluginsInfoActivity extends BaseFragment {
     }
 
     private void onItemClick(UItem item, View view, int position, float x, float y) {
+        if (!item.enabled) {
+            return;
+        }
         PluginsController controller = PluginsController.getInstance();
         if (item.id == ID_DEVELOPER_MODE) {
             controller.setDeveloperMode(!controller.isDeveloperMode());
@@ -175,6 +179,19 @@ public class PluginsInfoActivity extends BaseFragment {
         super.onResume();
         if (listView != null) {
             listView.adapter.update(false);
+        }
+    }
+
+    @Override
+    public boolean isSupportEdgeToEdge() {
+        return true;
+    }
+
+    @Override
+    public void onInsets(int left, int top, int right, int bottom) {
+        if (listView != null) {
+            listView.setPadding(0, 0, 0, bottom);
+            listView.setClipToPadding(false);
         }
     }
 }

--- a/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraAppearanceActivity.java
+++ b/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraAppearanceActivity.java
@@ -636,7 +636,7 @@ public class OpenExteraAppearanceActivity extends BaseNekoSettingsActivity {
                     view = chatListPreviewCell;
                     break;
                 case TYPE_FOLDERS:
-                    foldersPreviewCell = new FoldersPreviewCell(mContext);
+                    foldersPreviewCell = new FoldersPreviewCell(mContext, resourcesProvider);
                     view = foldersPreviewCell;
                     break;
                 case TYPE_FAB_SHAPE:

--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarMenu.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarMenu.java
@@ -159,6 +159,9 @@ public class ActionBarMenu extends LinearLayout {
         }
         menuItem.setOnClickListener(view -> {
             ActionBarMenuItem item = (ActionBarMenuItem) view;
+            if (!item.isSearchField() && searchFieldVisible()) {
+                return;
+            }
             if (item.hasSubMenu()) {
                 if (parentActionBar.actionBarMenuOnItemClick.canOpenMenu()) {
                     item.toggleSubMenu();

--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarMenuItem.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarMenuItem.java
@@ -323,6 +323,10 @@ public class ActionBarMenuItem extends FrameLayout {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
+        if (parentMenu != null && !isSearchField() && parentMenu.searchFieldVisible()) {
+            setPressed(false);
+            return true;
+        }
         if (event.getActionMasked() == MotionEvent.ACTION_DOWN) {
             if (longClickEnabled && hasSubMenu() && (popupWindow == null || !popupWindow.isShowing())) {
                 showMenuRunnable = () -> {
@@ -1505,6 +1509,7 @@ public class ActionBarMenuItem extends FrameLayout {
                 }
             };
             searchContainer.setClipChildren(searchItemPaddingStart != 0);
+            searchContainer.setClickable(true);
             wrappedSearchFrameLayout = null;
             if (wrapSearchInScrollView) {
                 wrappedSearchFrameLayout = new FrameLayout(getContext());

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollCreateCheckCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/PollCreateCheckCell.java
@@ -86,12 +86,10 @@ public class PollCreateCheckCell extends FrameLayout {
     public void setTextAndValueAndIconAndCheck(CharSequence text, CharSequence value, IconBackgroundColors color, int iconResId, boolean checked) {
         textView.setText(text);
 
-        final boolean border = resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark();
         SettingsActivity.SettingCell.Background drawable = new SettingsActivity.SettingCell.Background();
-        drawable.setColor(color.top, color.bottom);
-        drawable.setDrawBorder(border);
         imageView.setBackground(drawable);
         imageView.setImageResource(iconResId);
+        SettingsActivity.SettingCell.applyIconColors(imageView, drawable, color.top, color.bottom, resourcesProvider);
         checkBox.setChecked(checked, 0, animationsEnabled);
         multilineValueTextView.setText(value);
         checkBox.setContentDescription(text);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCell.java
@@ -12,7 +12,6 @@ import static org.telegram.messenger.AndroidUtilities.dp;
 
 import android.content.Context;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
 import android.graphics.PixelFormat;
@@ -628,13 +627,10 @@ public class TextCell extends FrameLayout {
         imageView.setPadding(dp(2), dp(2), dp(2), dp(2));
         imageView.setTranslationX(dp(LocaleController.isRTL ? 0 : -3));
         imageView.setImageResource(resId);
-        imageView.setColorFilter(new PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN));
 
-        final boolean border = resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark();
         SettingsActivity.SettingCell.Background drawable = new SettingsActivity.SettingCell.Background();
-        drawable.setColor(colorTop, colorBottom);
-        drawable.setDrawBorder(border);
         imageView.setBackground(drawable);
+        SettingsActivity.SettingCell.applyIconColors(imageView, drawable, colorTop, colorBottom, resourcesProvider);
     }
 
     public void setTextAndCheck(CharSequence text, boolean checked, boolean divider) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/FilterTabsView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/FilterTabsView.java
@@ -915,6 +915,7 @@ public class FilterTabsView extends FrameLayout {
     private final int listViewPaddingH;
     private final LinearLayoutManager layoutManager;
     private final ListAdapter adapter;
+    private boolean horizontalScrollingEnabled = true;
 
     private FilterTabsViewDelegate delegate;
 
@@ -1173,6 +1174,11 @@ public class FilterTabsView extends FrameLayout {
         listView.setLayoutManager(layoutManager = new LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false) {
 
             @Override
+            public boolean canScrollHorizontally() {
+                return horizontalScrollingEnabled && super.canScrollHorizontally();
+            }
+
+            @Override
             public boolean supportsPredictiveItemAnimations() {
                 return true;
             }
@@ -1203,7 +1209,7 @@ public class FilterTabsView extends FrameLayout {
 
             @Override
             public int scrollHorizontallyBy(int dx, RecyclerView.Recycler recycler, RecyclerView.State state) {
-                if (delegate.isTabMenuVisible()) {
+                if (!horizontalScrollingEnabled || delegate.isTabMenuVisible()) {
                     dx = 0;
                 }
                 return super.scrollHorizontallyBy(dx, recycler, state);
@@ -1353,6 +1359,13 @@ public class FilterTabsView extends FrameLayout {
 
     public RecyclerListView getTabsContainer() {
         return listView;
+    }
+
+    public void setHorizontalScrollingEnabled(boolean enabled) {
+        horizontalScrollingEnabled = enabled;
+        if (!enabled) {
+            listView.stopScroll();
+        }
     }
 
     public int getNextPageId(boolean forward) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/GlassOutlineStyle.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/GlassOutlineStyle.java
@@ -2,6 +2,10 @@ package org.telegram.ui.Components.blur3;
 
 import app.exteraless.appearance.AppearanceConfig;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+
 /**
  * Стиль контура «стеклянных» поверхностей.
  * GLARE(0), SOLID(1), HIDDEN(2);
@@ -16,6 +20,28 @@ public enum GlassOutlineStyle {
     HIDDEN;
 
     private static final GlassOutlineStyle[] VALUES = values();
+    private static final Set<Listener> listeners = Collections.newSetFromMap(new WeakHashMap<>());
+
+    // made with <3 from uzbekgram
+    public interface Listener {
+        void onGlassOutlineStyleChanged();
+    }
+
+    public static void addListener(Listener listener) {
+        synchronized (listeners) {
+            listeners.add(listener);
+        }
+    }
+
+    public static void dispatchChange() {
+        final Listener[] snapshot;
+        synchronized (listeners) {
+            snapshot = listeners.toArray(new Listener[0]);
+        }
+        for (Listener listener : snapshot) {
+            listener.onGlassOutlineStyleChanged();
+        }
+    }
 
     /** Текущий стиль из настроек; неизвестное значение трактуется как {@link #GLARE}. */
     public static GlassOutlineStyle current() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/StrokeDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/StrokeDrawable.java
@@ -17,7 +17,7 @@ import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.blur3.drawable.BlurredBackgroundDrawable;
 import org.telegram.ui.Components.blur3.drawable.color.BlurredBackgroundColorProvider;
 
-public class StrokeDrawable extends Drawable {
+public class StrokeDrawable extends Drawable implements GlassOutlineStyle.Listener {
 
     private BlurredBackgroundColorProvider colorProvider;
     protected int strokeColorTop, strokeColorBottom;
@@ -43,6 +43,7 @@ public class StrokeDrawable extends Drawable {
     }
 
     public void setColorProvider(BlurredBackgroundColorProvider colorProvider) {
+        GlassOutlineStyle.addListener(this);
         this.colorProvider = colorProvider;
 
         paintStrokeTop.setStyle(Paint.Style.STROKE);
@@ -50,6 +51,12 @@ public class StrokeDrawable extends Drawable {
         paintStrokeFull.setStyle(Paint.Style.STROKE);
 
         updateColors();
+    }
+
+    @Override
+    public void onGlassOutlineStyleChanged() {
+        updateColors();
+        invalidateSelf();
     }
 
     /** Как было; SOLID — сплошной контур; HIDDEN — без контура. */

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/BlurredBackgroundDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/blur3/drawable/BlurredBackgroundDrawable.java
@@ -45,7 +45,7 @@ import java.util.Arrays;
 
 import xyz.nextalone.nagram.NaConfig;
 
-public abstract class BlurredBackgroundDrawable extends Drawable {
+public abstract class BlurredBackgroundDrawable extends Drawable implements GlassOutlineStyle.Listener {
     public BlurredBackgroundDrawable() {
         boundProps.strokeWidthTop = dpf2(1);
         boundProps.strokeWidthBottom = dpf2(2 / 3f);
@@ -193,6 +193,7 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
     protected int strokeColorFull;
 
     public BlurredBackgroundDrawable setColorProvider(BlurredBackgroundColorProvider colorProvider) {
+        GlassOutlineStyle.addListener(this);
         this.colorProvider = colorProvider;
         updateColors();
 
@@ -202,6 +203,11 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
             // параметры тени выставляет updateColors()
         }
         return this;
+    }
+
+    @Override
+    public void onGlassOutlineStyleChanged() {
+        updateColors();
     }
 
     /**
@@ -450,7 +456,7 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
         float[] radii, float strokeWidth, boolean isTop,
         Paint paint
     ) {
-        if (!NaConfig.INSTANCE.getStrokeOnViews().Bool()) return;
+        if (!NaConfig.INSTANCE.getStrokeOnViews().Bool() || GlassOutlineStyle.current() != GlassOutlineStyle.GLARE) return;
 
         final boolean radiiAreSame = isTop ?
             radii[0] == radii[1] && radii[1] == radii[2] && radii[2] == radii[3]:
@@ -552,7 +558,7 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
 
     public static void drawStroke(Canvas canvas, float left, float top, float right, float bottom,
                                      float radii, float strokeWidth, boolean isTop, Paint paint) {
-        if (!NaConfig.INSTANCE.getStrokeOnViews().Bool()) return;
+        if (!NaConfig.INSTANCE.getStrokeOnViews().Bool() || GlassOutlineStyle.current() != GlassOutlineStyle.GLARE) return;
         final float strokeHalf = strokeWidth / 2f;
         canvas.save();
         if (isTop) {
@@ -706,7 +712,9 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
             return;
         }
 
-        final NinePatchDrawable ninePatchDrawable = checkNinePatchDrawable(fillColor, NaConfig.INSTANCE.getStrokeOnViews().Bool());
+        final boolean withStroke = boundProps.useFullStroke ||
+                NaConfig.INSTANCE.getStrokeOnViews().Bool() && GlassOutlineStyle.current() == GlassOutlineStyle.GLARE;
+        final NinePatchDrawable ninePatchDrawable = checkNinePatchDrawable(fillColor, withStroke);
         ninePatchDrawable.setBounds(
             boundProps.boundsWithPadding.left - ninePatchDrawablePadding.left,
             boundProps.boundsWithPadding.top - ninePatchDrawablePadding.top,
@@ -761,7 +769,8 @@ public abstract class BlurredBackgroundDrawable extends Drawable {
     }
 
     private void drawStrokeInternalIfNeeded(Canvas canvas) {
-        if (!NaConfig.INSTANCE.getStrokeOnViews().Bool()) return;
+        if (!boundProps.useFullStroke &&
+                (!NaConfig.INSTANCE.getStrokeOnViews().Bool() || GlassOutlineStyle.current() != GlassOutlineStyle.GLARE)) return;
 
         if (boundProps.useFullStroke) {
             final int strokeColorFull = Theme.multAlpha(this.strokeColorFull, alpha / 255f);

--- a/TMessagesProj/src/main/java/org/telegram/ui/DataUsage2Activity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DataUsage2Activity.java
@@ -1051,12 +1051,11 @@ public class DataUsage2Activity extends BaseFragment {
             } else {
                 imageView.setVisibility(View.VISIBLE);
 
-                final boolean border = resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark();
                 SettingsActivity.SettingCell.Background drawable = new SettingsActivity.SettingCell.Background();
-                drawable.setColor(imageColorTop, imageColorBottom);
-                drawable.setDrawBorder(border);
                 imageView.setBackground(drawable);
                 imageView.setImageResource(imageResId);
+                SettingsActivity.SettingCell.applyIconColors(imageView, drawable,
+                        imageColorTop, imageColorBottom, resourcesProvider);
             }
 
             textView.setText(title);

--- a/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
@@ -1296,24 +1296,8 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
             titleView.setTranslationX(icon == 0 ? dp(2) : 0);
             subtitleView.setTranslationX(icon == 0 ? dp(2) : 0);
 
-            final boolean monet = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && Theme.getActiveTheme().isMonet();
-            final int monetIconColor;
-            if (monet) {
-                final boolean dark = resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark();
-                final int backgroundColor = MonetHelper.getColor(dark ? "a1_200" : "a1_600");
-                iconBackground.setMonetColor(backgroundColor);
-                monetIconColor = MonetHelper.getColor(dark ? "a1_800" : "a1_100");
-            } else {
-                iconBackground.setColor(iconColorTop, iconColorBottom);
-                monetIconColor = Color.TRANSPARENT;
-            }
-
             iconView.setImageResource(icon);
-            if (monet) {
-                iconView.setColorFilter(monetIconColor, PorterDuff.Mode.SRC_IN);
-            } else {
-                iconView.clearColorFilter();
-            }
+            applyIconColors(iconView, iconBackground, iconColorTop, iconColorBottom, resourcesProvider);
             // exteraGram, SettingsActivity.java:577 — строке-входу в настройки форка ставится
             // CENTER_CROP, чтобы логотип занял всю плашку, остальным CENTER.
             iconView.setScaleType(icon == R.drawable.exteraless_icon_tile
@@ -1322,6 +1306,24 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
             subtitleView.setVisibility((twoLines = !TextUtils.isEmpty(subtitle)) ? View.VISIBLE : View.GONE);
             subtitleView.setText(subtitle);
             setValue(value);
+        }
+
+        public static void applyIconColors(
+                ImageView iconView,
+                Background iconBackground,
+                int iconColorTop,
+                int iconColorBottom,
+                Theme.ResourcesProvider resourcesProvider
+        ) {
+            final boolean dark = resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && Theme.getActiveTheme().isMonet()) {
+                iconBackground.setMonetColor(MonetHelper.getColor(dark ? "a1_200" : "a1_600"));
+                iconView.setColorFilter(MonetHelper.getColor(dark ? "a1_800" : "a1_100"), PorterDuff.Mode.SRC_IN);
+            } else {
+                iconBackground.setColor(iconColorTop, iconColorBottom);
+                iconView.clearColorFilter();
+            }
+            iconBackground.setDrawBorder(dark);
         }
 
         public void setValue(CharSequence value) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
@@ -59,7 +59,6 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.collection.LongSparseArray;
-import androidx.core.graphics.ColorUtils;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
@@ -1297,14 +1296,24 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
             titleView.setTranslationX(icon == 0 ? dp(2) : 0);
             subtitleView.setTranslationX(icon == 0 ? dp(2) : 0);
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && Theme.getActiveTheme().isMonet()) {
-                int flatHarmonizedColor = MonetHelper.harmonizeColor(ColorUtils.blendARGB(iconColorTop, iconColorBottom, 0.5f));
-                iconColorTop = flatHarmonizedColor;
-                iconColorBottom = flatHarmonizedColor;
+            final boolean monet = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && Theme.getActiveTheme().isMonet();
+            final int monetIconColor;
+            if (monet) {
+                final boolean dark = resourcesProvider != null ? resourcesProvider.isDark() : Theme.isCurrentThemeDark();
+                final int backgroundColor = MonetHelper.getColor(dark ? "a1_200" : "a1_600");
+                iconBackground.setMonetColor(backgroundColor);
+                monetIconColor = MonetHelper.getColor(dark ? "a1_800" : "a1_100");
+            } else {
+                iconBackground.setColor(iconColorTop, iconColorBottom);
+                monetIconColor = Color.TRANSPARENT;
             }
 
-            iconBackground.setColor(iconColorTop, iconColorBottom);
             iconView.setImageResource(icon);
+            if (monet) {
+                iconView.setColorFilter(monetIconColor, PorterDuff.Mode.SRC_IN);
+            } else {
+                iconView.clearColorFilter();
+            }
             // exteraGram, SettingsActivity.java:577 — строке-входу в настройки форка ставится
             // CENTER_CROP, чтобы логотип занял всю плашку, остальным CENTER.
             iconView.setScaleType(icon == R.drawable.exteraless_icon_tile
@@ -1342,8 +1351,17 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
             }
 
             public void setColor(int topColor, int bottomColor) {
+                monet = false;
                 gradient = new LinearGradient(0, 0, 0, dp(28), new int[] { topColor, bottomColor }, new float[] { 0, 1 }, Shader.TileMode.CLAMP);
                 paint.setShader(gradient);
+            }
+
+            private boolean monet;
+            public void setMonetColor(int color) {
+                monet = true;
+                gradient = null;
+                paint.setShader(null);
+                paint.setColor(color);
             }
 
             private boolean border;
@@ -1359,7 +1377,7 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
                 matrix.postTranslate(AndroidUtilities.rectTmp.left, AndroidUtilities.rectTmp.top);
                 canvas.drawRoundRect(AndroidUtilities.rectTmp, r, r, paint);
 
-                if (GlassOutlineStyle.current() == GlassOutlineStyle.GLARE && border) {
+                if (!monet && GlassOutlineStyle.current() == GlassOutlineStyle.GLARE && border) {
                     final float sw = dp(1);
                     strokePaint.setStrokeWidth(sw);
                     matrix.reset();

--- a/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
@@ -131,6 +131,7 @@ import org.telegram.ui.Components.UndoView;
 import org.telegram.ui.Components.UniversalAdapter;
 import org.telegram.ui.Components.UniversalRecyclerView;
 import org.telegram.ui.Components.blur3.DownscaleScrollableNoiseSuppressor;
+import org.telegram.ui.Components.blur3.GlassOutlineStyle;
 import org.telegram.ui.Components.blur3.ViewGroupPartRenderer;
 import org.telegram.ui.Components.blur3.capture.IBlur3Capture;
 import org.telegram.ui.Components.blur3.source.BlurredBackgroundSourceRenderNode;
@@ -1327,7 +1328,7 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
             );
         }
 
-        public static class Background extends Drawable {
+        public static class Background extends Drawable implements GlassOutlineStyle.Listener {
             private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
             private final Paint strokePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
             private LinearGradient gradient, strokeGradient;
@@ -1337,6 +1338,7 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
                 strokePaint.setStyle(Paint.Style.STROKE);
                 strokeGradient = new LinearGradient(0, 0, 0, dp(28), new int[] { 0x4dffffff, 0, 0x1affffff }, new float[] { 0, 0.5f, 1 }, Shader.TileMode.CLAMP);
                 strokePaint.setShader(strokeGradient);
+                GlassOutlineStyle.addListener(this);
             }
 
             public void setColor(int topColor, int bottomColor) {
@@ -1357,7 +1359,7 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
                 matrix.postTranslate(AndroidUtilities.rectTmp.left, AndroidUtilities.rectTmp.top);
                 canvas.drawRoundRect(AndroidUtilities.rectTmp, r, r, paint);
 
-                if (border) {
+                if (GlassOutlineStyle.current() == GlassOutlineStyle.GLARE && border) {
                     final float sw = dp(1);
                     strokePaint.setStrokeWidth(sw);
                     matrix.reset();
@@ -1365,6 +1367,11 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
                     AndroidUtilities.rectTmp.inset(sw / 2.0f, sw / 2.0f);
                     canvas.drawRoundRect(AndroidUtilities.rectTmp, r, r, strokePaint);
                 }
+            }
+
+            @Override
+            public void onGlassOutlineStyleChanged() {
+                invalidateSelf();
             }
 
             @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/community/cells/CommunityRequestsCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/community/cells/CommunityRequestsCell.java
@@ -114,8 +114,9 @@ public class CommunityRequestsCell extends LinearLayout implements Theme.Colorab
         iconLayout.setVisibility(icon != 0 ? View.VISIBLE : View.GONE);
         titleView.setTranslationX(icon == 0 ? dp(2) : 0);
 
-        iconBackground.setColor(iconColorTop, iconColorBottom);
         iconView.setImageResource(icon);
+        SettingsActivity.SettingCell.applyIconColors(iconView, iconBackground,
+                iconColorTop, iconColorBottom, resourcesProvider);
         setTitle(title);
         setValue(value);
         setUnreadMode(valueAsUnread);

--- a/TMessagesProj/src/main/kotlin/app/exteraless/appearance/AppearanceConfig.kt
+++ b/TMessagesProj/src/main/kotlin/app/exteraless/appearance/AppearanceConfig.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import org.telegram.messenger.AndroidUtilities
 import org.telegram.messenger.ApplicationLoader
 import org.telegram.messenger.FileLog
+import org.telegram.ui.Components.blur3.GlassOutlineStyle
 import tw.nekomimi.nekogram.NekoConfig
 import tw.nekomimi.nekogram.config.ConfigItem
 
@@ -139,7 +140,13 @@ object AppearanceConfig {
     /** Стиль стеклянного контура: 0 — блик, 1 — сплошной, 2 — скрыт. Только UI. */
     @JvmField
     val glassOutlineStyle =
-        addConfig("OEAppearanceGlassOutlineStyle", ConfigItem.configTypeInt, 0)
+        addConfig(object : ConfigItem("OEAppearanceGlassOutlineStyle", ConfigItem.configTypeInt, 0) {
+            override fun setConfigInt(v: Int) {
+                val changed = Int() != v
+                super.setConfigInt(v)
+                if (changed) GlassOutlineStyle.dispatchChange()
+            }
+        })
 
     /** Стеклянное меню сообщения. Дефолт true, как в exteraGram (BooleanPref(1)). */
     @JvmField
@@ -378,6 +385,11 @@ object AppearanceConfig {
         return item
     }
 
+    private fun addConfig(item: ConfigItem): ConfigItem {
+        configs.add(item)
+        return item
+    }
+
     @JvmStatic
     fun ensureLoaded() {
         if (!configLoaded) loadConfig(false)
@@ -431,5 +443,6 @@ object AppearanceConfig {
             }
             editor.apply()
         }
+        GlassOutlineStyle.dispatchChange()
     }
 }


### PR DESCRIPTION
полноценный реворк экрана плагинов (теперь выглядит нормально), новый стиль для превью папок, реворк "стиля обводки" (обновляется реактивно) и адаптация иконок в настройках под monet тему

экран плагинов:

- вместо эмодзи показывается стикер, если плагинов нет
- свитч наследует глобальный вид
- выключенные опции в настройках плагинов теперь некликабельны
- оптимизация под edge-to-edge
- ссылка на "доверенные плагины" заменена на правильную
- фикс риппла на карточках плагинов и внешних отступов

<img width="1080" height="2340" alt="photo" src="https://github.com/user-attachments/assets/4bc7a82b-86d1-4f63-9e39-605244f44471" />

превью папок:

- наследует компонент из списка чатов
- фон и бордер у превью убраны

<img width="1080" height="2340" alt="photo" src="https://github.com/user-attachments/assets/3e59397a-e029-4a86-843c-986f9d0eab23" />

иконки в настройках и обводка стекла:

- вид иконок без "стекла", если оно выключено
- обводка теперь обновляется реактивно

<img width="125" height="1064" alt="photo" src="https://github.com/user-attachments/assets/5f39bb0f-f05b-44ab-a297-ce14b1b7d7e6" />

протестировано и работает стабильно на Galaxy S23 (debug сборка)
не забудь отметить меня (@alosykabla) в чейнджлоге) 