### PR TITLE
feat(ui): add Slide back animation style

### DIFF
--- a/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraAppNavigationActivity.java
+++ b/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraAppNavigationActivity.java
@@ -143,7 +143,7 @@ public class OpenExteraAppNavigationActivity extends BaseFragment {
         // Вместо переключателя Spring Animations здесь трёхпозиционный
         // NaConfig.backAnimationStyle: он покрывает и Spring, и Classic.
         items.add(UItem.asButton(ID_BACK_ANIMATION, getString(R.string.OEBackAnimation),
-                backAnimations()[clamp(NaConfig.INSTANCE.getBackAnimationStyle().Int(), 3)]));
+                backAnimations()[clamp(NaConfig.INSTANCE.getBackAnimationStyle().Int(), 4)]));
         items.add(UItem.asShadow(getString(R.string.OEBackAnimationInfo)));
 
         if (android.os.Build.VERSION.SDK_INT >= 34) {
@@ -446,6 +446,7 @@ public class OpenExteraAppNavigationActivity extends BaseFragment {
                 getString(R.string.OEBackAnimationClassic),
                 getString(R.string.OEBackAnimationSpring),
                 getString(R.string.OEBackAnimationPredictive),
+                getString(R.string.OEBackAnimationSlide),
         };
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/ActionBarLayout.java
@@ -1183,7 +1183,7 @@ public class ActionBarLayout extends FrameLayout implements INavigationLayout, F
                 final WindowInsets insets = getRootWindowInsets();
                 if (insets != null) {
                     AndroidUtilities.rectTmp.set(translationX, 0, translationX + getWidth(), getHeight());
-                    if (newBackTransitions()) {
+                    if (newBackTransitions() && NaConfig.INSTANCE.getBackAnimationStyle().Int() != BACK_ANIMATION_SLIDE) {
                         final float scale;
                         if (predictiveBackInProgress) {
                             scale = lerp(1.00f, lerp(0.90f, 0.85f, 1.0f - containerView.getAlpha()), clamp01(translationX / dpf2(56)));
@@ -1806,7 +1806,7 @@ public class ActionBarLayout extends FrameLayout implements INavigationLayout, F
         predictiveInput = true;
         predictiveBackLeft = touchX < AndroidUtilities.displaySize.x / 2f;
         predictiveBackY = touchY;
-        m3PredictiveBack = !isSheet;
+        m3PredictiveBack = !isSheet && NaConfig.INSTANCE.getBackAnimationStyle().Int() == BACK_ANIMATION_PREDICTIVE;
         if (m3PredictiveBack) {
             predictiveBackAnimation.start(
                     containerView.getMeasuredWidth(),
@@ -1837,6 +1837,13 @@ public class ActionBarLayout extends FrameLayout implements INavigationLayout, F
         // Чувствительность применяется только к живому жесту; докат и откат зовут
         // applyPredictiveBackProgress напрямую, иначе множитель наложился бы дважды
         t = app.exteraless.utils.UtilsConfig.adjustPredictiveBackProgress(t);
+        if (NaConfig.INSTANCE.getBackAnimationStyle().Int() == BACK_ANIMATION_SLIDE) {
+            final float dx = dp(180) * CubicBezierInterpolator.StandardDecelerate.getInterpolation(t);
+            predictiveBackHasProgress = t > 0;
+            containerView.setTranslationX(dx);
+            setInnerTranslationX(dx);
+            return;
+        }
         if (m3PredictiveBack) {
             applyPredictiveBackProgress(t, touchY);
             return;
@@ -1909,7 +1916,7 @@ public class ActionBarLayout extends FrameLayout implements INavigationLayout, F
                 if (USE_ACTIONBAR_CROSSFADE) {
                     swipeProgress = progress;
                 }
-                if (!m3PredictiveBack) {
+                if (!m3PredictiveBack && !predictiveBackInProgress) {
                     // openExtera: доводим масштаб и вертикальный сдвиг карточки после отпускания
                     final float m3s = AndroidUtilities.lerp(1.0f, 0.85f, MathUtils.clamp(progress, 0f, 1f));
                     containerView.setScaleX(m3s);
@@ -4145,6 +4152,7 @@ public class ActionBarLayout extends FrameLayout implements INavigationLayout, F
     // public static final int BACK_ANIMATION_CLASSIC = 0;
     public static final int BACK_ANIMATION_SPRING = 1;
     public static final int BACK_ANIMATION_PREDICTIVE = 2;
+    public static final int BACK_ANIMATION_SLIDE = 3;
     private static final boolean USE_SPRING_ANIMATION = NaConfig.INSTANCE.getBackAnimationStyle().Int() == BACK_ANIMATION_SPRING;
     private static final boolean USE_ACTIONBAR_CROSSFADE = USE_SPRING_ANIMATION && NaConfig.INSTANCE.getSpringAnimationCrossfade().Bool();
     private static final float SPRING_STIFFNESS = 900f;

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoExperimentalSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoExperimentalSettingsActivity.java
@@ -106,6 +106,7 @@ public class NekoExperimentalSettingsActivity extends BaseNekoXSettingsActivity 
                     getString(R.string.BackAnimationClassic),
                     getString(R.string.BackAnimationSpring),
                     getString(R.string.BackAnimationPredictive),
+                    getString(R.string.OEBackAnimationSlide),
             } : new String[]{
                     getString(R.string.BackAnimationClassic),
                     getString(R.string.BackAnimationSpring),

--- a/TMessagesProj/src/main/res/values-es/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values-es/strings_oe_appearance.xml
@@ -77,6 +77,7 @@
     <string name="OEBackAnimationClassic">Clásica</string>
     <string name="OEBackAnimationSpring">Elástica</string>
     <string name="OEBackAnimationPredictive">Retroceso predictivo</string>
+    <string name="OEBackAnimationSlide">Deslizar</string>
     <string name="OEBackAnimationInfo">Activa animaciones más suaves al cambiar de pantalla y al abrir el menú lateral.</string>
     <string name="OEPredictiveBackIntensity">Intensidad del gesto</string>
     <string name="OEPredictiveBackOff">Desactivada</string>

--- a/TMessagesProj/src/main/res/values-pl-rPL/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values-pl-rPL/strings_oe_appearance.xml
@@ -77,6 +77,7 @@
     <string name="OEBackAnimationClassic">Klasyczna</string>
     <string name="OEBackAnimationSpring">Sprężysta</string>
     <string name="OEBackAnimationPredictive">Przewidywane cofanie</string>
+    <string name="OEBackAnimationSlide">Przesunięcie</string>
     <string name="OEBackAnimationInfo">Włącza płynniejsze animacje przy przełączaniu ekranów i otwieraniu menu bocznego.</string>
     <string name="OEPredictiveBackIntensity">Siła gestu</string>
     <string name="OEPredictiveBackOff">Wyłączona</string>

--- a/TMessagesProj/src/main/res/values-ru-rRU/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values-ru-rRU/strings_oe_appearance.xml
@@ -75,6 +75,7 @@
     <string name="OEBackAnimationClassic">Классическая</string>
     <string name="OEBackAnimationSpring">Пружинная</string>
     <string name="OEBackAnimationPredictive">Предиктивная</string>
+    <string name="OEBackAnimationSlide">Скольжение</string>
     <string name="OEPredictiveBackIntensity">Интенсивность жеста</string>
     <string name="OEPredictiveBackOff">Выкл</string>
     <string name="OEPredictiveBackMax">Макс</string>

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_oe_appearance.xml
@@ -77,6 +77,7 @@
     <string name="OEBackAnimationClassic">经典</string>
     <string name="OEBackAnimationSpring">弹性</string>
     <string name="OEBackAnimationPredictive">预测性返回</string>
+    <string name="OEBackAnimationSlide">平移</string>
     <string name="OEBackAnimationInfo">在切换界面和打开侧边菜单时启用更流畅的动画。</string>
     <string name="OEPredictiveBackIntensity">手势幅度</string>
     <string name="OEPredictiveBackOff">关闭</string>

--- a/TMessagesProj/src/main/res/values/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values/strings_oe_appearance.xml
@@ -95,6 +95,7 @@
     <string name="OEBackAnimationClassic">Classic</string>
     <string name="OEBackAnimationSpring">Spring</string>
     <string name="OEBackAnimationPredictive">Predictive Back</string>
+    <string name="OEBackAnimationSlide">Slide</string>
     <string name="OEBackAnimationInfo">Enables smoother animations when switching screens and opening the side menu.</string>
     <string name="OEPredictiveBackIntensity">Gesture Intensity</string>
     <string name="OEPredictiveBackOff">Off</string>


### PR DESCRIPTION
- New BACK_ANIMATION_SLIDE (3): finger-following pure translation (180dp cap, decelerate curve) with physical rounded-corner clipping, no card scaling
- Gate M3 predictive back cards to the Predictive style only; Classic/Spring now take their natural gesture paths
- Skip spring-route card scale for gesture-driven spring commits
- Add OEBackAnimationSlide strings (en, zh-rCN, es, ru-rRU, pl-rPL) and a fourth option in both settings screens