### PR TITLE
Keep the full sensor angle in round videos

### DIFF
--- a/TMessagesProj/src/main/java/app/exteraless/camera/CameraXSession.java
+++ b/TMessagesProj/src/main/java/app/exteraless/camera/CameraXSession.java
@@ -493,6 +493,15 @@ public class CameraXSession {
                 return cmp;
             }
         }
+        // Угол обзора важнее 60 кадров: 16:9 у Pixel — это кроп 4:3 (3840×2160 из
+        // 3840×2736), и кружок из него теряет ~20 % ширины. 60 fps берём только
+        // среди размеров с тем же углом.
+        int cmp = Long.compare(
+                calculateFieldOfViewPenalty(aShort, aLong, sensorShort, sensorLong) * bShort,
+                calculateFieldOfViewPenalty(bShort, bLong, sensorShort, sensorLong) * aShort);
+        if (cmp != 0) {
+            return cmp;
+        }
         final boolean aFast = capable60.contains(a);
         if (aFast != capable60.contains(b)) {
             return aFast ? -1 : 1;
@@ -502,16 +511,10 @@ public class CameraXSession {
             return aComfortable ? -1 : 1;
         }
         if (!aComfortable) {
-            int cmp = Integer.compare(bShort, aShort);
+            cmp = Integer.compare(bShort, aShort);
             if (cmp != 0) {
                 return cmp;
             }
-        }
-        int cmp = Long.compare(
-                calculateFieldOfViewPenalty(aShort, aLong, sensorShort, sensorLong) * bShort,
-                calculateFieldOfViewPenalty(bShort, bLong, sensorShort, sensorLong) * aShort);
-        if (cmp != 0) {
-            return cmp;
         }
         cmp = Integer.compare(Math.abs(aShort - comfortable), Math.abs(bShort - comfortable));
         if (cmp != 0) {
@@ -731,11 +734,17 @@ public class CameraXSession {
         control.setZoomRatio(state.getMinZoomRatio());
     }
 
-    /** Широкий угол имеет смысл только на основной камере: у фронталки его нет. */
+    /**
+     * Основная камера — по настройке. Фронталка — всегда: у неё зум меньше единицы
+     * означает не другую линзу, а полный сенсор вместо кропа (Pixel: 0.9× — это
+     * 3840×2736 против 3440×2448 на «1×»), и это её штатный угол.
+     */
     private boolean wantsWideAngleStart(Camera camera) {
-        return ChatsConfig.startWithWideAngleCamera.Bool()
-                && camera != null
-                && camera.getCameraInfo().getLensFacing() == CameraSelector.LENS_FACING_BACK;
+        if (camera == null) {
+            return false;
+        }
+        return camera.getCameraInfo().getLensFacing() == CameraSelector.LENS_FACING_FRONT
+                || ChatsConfig.startWithWideAngleCamera.Bool();
     }
 
     public void focusToPoint(float x, float y, float viewWidth, float viewHeight) {

--- a/TMessagesProj/src/main/java/app/exteraless/camera/InstantCameraZoomSlider.java
+++ b/TMessagesProj/src/main/java/app/exteraless/camera/InstantCameraZoomSlider.java
@@ -175,12 +175,21 @@ public class InstantCameraZoomSlider extends CameraZoomSliderView {
         return result;
     }
 
-    private static float[] buildRulerStops(float min, float max) {
-        return boundStops(new float[]{min, 1f, 2f, 5f, 10f, 30f, max}, min, max, true);
+    /** {@code unit} — реальная кратность, которая подписывается как «1×». */
+    private static float[] buildRulerStops(float min, float max, float unit) {
+        final float[] stops = boundStops(new float[]{min, unit, 2f * unit, 5f * unit, 10f * unit, 30f * unit}, min, max, false);
+        // Край подписываем отдельно, только если он заметно дальше последнего деления:
+        // иначе на фронталке Pixel рядом встают «10» и «11».
+        if (stops.length == 0 || stops[stops.length - 1] * 1.15f < max) {
+            return boundStops(stops, min, max, true);
+        }
+        return stops;
     }
 
-    private static float[] buildToggleStops(boolean frontFace, float min, float max) {
-        return boundStops(frontFace ? new float[]{min, 1f, 2f} : new float[]{min, 1f, 2f, 5f}, min, max, false);
+    private static float[] buildToggleStops(boolean frontFace, float min, float max, float unit) {
+        return boundStops(frontFace
+            ? new float[]{min, unit, 2f * unit}
+            : new float[]{min, unit, 2f * unit, 5f * unit}, min, max, false);
     }
 
     // ---------- Camera1 ----------
@@ -559,6 +568,7 @@ public class InstantCameraZoomSlider extends CameraZoomSliderView {
                 }
                 minRatio = camera2Session.getMinZoom();
                 maxRatio = camera2Session.getMaxZoom();
+                frontFace = camera2Session.isFront();
                 break;
             }
             case CAMERA_1: {
@@ -588,13 +598,15 @@ public class InstantCameraZoomSlider extends CameraZoomSliderView {
             return;
         }
 
-        defaultZoom = clamp(1f, minRatio, maxRatio);
+        // Фронталка: её минимум — полный сенсор, а не другая линза (Pixel: 0.9×), и это
+        // штатный угол. Подписываем его как «1×» и от него же считаем «2×».
+        displayOneZoom = frontFace ? minRatio : 1f;
+        defaultZoom = clamp(displayOneZoom, minRatio, maxRatio);
         wideZoom = minRatio;
-        displayOneZoom = 1f;
-        setDisplayNormalizationFactor(1f);
+        setDisplayNormalizationFactor(displayOneZoom);
 
-        final float[] toggles = buildToggleStops(frontFace, minRatio, maxRatio);
-        final float[] ruler = buildRulerStops(minRatio, maxRatio);
+        final float[] toggles = buildToggleStops(frontFace, minRatio, maxRatio, displayOneZoom);
+        final float[] ruler = buildRulerStops(minRatio, maxRatio, displayOneZoom);
         final float current = clamp(
             backend == Backend.CAMERA_X ? getCameraXResetZoom()
                 : backend == Backend.CAMERA_2 ? camera2Session.getZoom()

--- a/TMessagesProj/src/main/java/org/telegram/messenger/camera/Camera2Session.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/camera/Camera2Session.java
@@ -71,8 +71,10 @@ public class Camera2Session {
     private final CameraCaptureSession.StateCallback captureStateCallback;
     private CaptureRequest.Builder captureRequestBuilder;
     private Rect sensorSize;
+    private float minZoom = 1f;
     private float maxZoom = 1f;
     private float currentZoom = 1f;
+    private Range<Float> zoomRatioRange;
 
     private final Size previewSize;
 
@@ -196,6 +198,15 @@ public class Camera2Session {
             sensorSize = cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
             final Float value = cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM);
             maxZoom = (value == null || value < 1f) ? 1f : value;
+            // Кратность вместо кропа: у логической камеры диапазон начинается ниже единицы
+            // (ширик основной, полный сенсор фронталки), кроп-регион туда не достаёт.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                zoomRatioRange = cameraCharacteristics.get(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE);
+                if (zoomRatioRange != null) {
+                    minZoom = zoomRatioRange.getLower();
+                    maxZoom = zoomRatioRange.getUpper();
+                }
+            }
             cameraManager.openCamera(cameraId, cameraStateCallback, handler);
         } catch (Exception e) {
             FileLog.e(e);
@@ -342,10 +353,11 @@ public class Camera2Session {
 
     private final Rect cropRegion = new Rect();
     public void setZoom(float value) {
+        // Запоминаем и до открытия: стартовый запрос возьмёт это значение сам.
+        currentZoom = Utilities.clamp(value, maxZoom, minZoom);
         if (!isInitiated()) return;
         if (captureRequestBuilder == null || cameraDevice == null || sensorSize == null) return;
 
-        currentZoom = Utilities.clamp(value, maxZoom, 1f);
         updateCaptureRequest();
 
         try {
@@ -375,8 +387,11 @@ public class Camera2Session {
     }
 
     public float getMinZoom() {
-        // TODO: support wide zoom camera switching
-        return 1f;
+        return minZoom;
+    }
+
+    public boolean isFront() {
+        return isFront;
     }
 
     public int getPreviewWidth() {
@@ -510,7 +525,9 @@ public class Camera2Session {
                 chooseFocusMode(captureRequestBuilder);   // без настройки, как в exteraGram
             }
 
-            if (sensorSize != null && Math.abs(currentZoom - 1f) >= 0.01f) {
+            if (zoomRatioRange != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                captureRequestBuilder.set(CaptureRequest.CONTROL_ZOOM_RATIO, currentZoom);
+            } else if (sensorSize != null && Math.abs(currentZoom - 1f) >= 0.01f) {
                 final int centerX = sensorSize.width() / 2;
                 final int centerY = sensorSize.height() / 2;
                 final int deltaX = (int) ((0.5f * sensorSize.width()) / currentZoom);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraSessionWrapper.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/camera/CameraSessionWrapper.java
@@ -145,7 +145,8 @@ public class CameraSessionWrapper {
 
     public void setZoom(float zoom) {
         if (camera2Session != null) {
-            camera2Session.setZoom(AndroidUtilities.lerp(camera2Session.getMinZoom(), camera2Session.getMaxZoom(), zoom));
+            // Сторис живут в 1×..max, как раньше: ниже единицы — только кружки.
+            camera2Session.setZoom(AndroidUtilities.lerp(Math.max(1f, camera2Session.getMinZoom()), camera2Session.getMaxZoom(), zoom));
         } else if (camera1Session != null) {
             camera1Session.setZoom(zoom);
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/InstantCameraView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/InstantCameraView.java
@@ -4206,7 +4206,7 @@ public class InstantCameraView extends FrameLayout implements NotificationCenter
                 steps = 1;
             }
             final float factor = (float) Math.pow(maxZoom, 1.0d / steps);
-            final float raw = up ? from * factor : Math.max(1.0f, from / factor);
+            final float raw = up ? from * factor : Math.max(minZoom, from / factor);
             target = Utilities.clamp(raw, maxZoom, minZoom);
         } else {
             from = Utilities.clamp(pinchScale, 1f, 0f);
@@ -4474,8 +4474,17 @@ public class InstantCameraView extends FrameLayout implements NotificationCenter
             }
             final float min = session.getMinZoom();
             final float max = session.getMaxZoom();
-            final float zoom = max <= min ? min : min + lockedZoom * (max - min);
-            session.whenDone(() -> session.setZoom(zoom));
+            // Пока зум не трогали: основная — 1×, ширик только по настройке; фронталка —
+            // полный сенсор (её минимум), как в CameraXSession.wantsWideAngleStart.
+            final float zoom;
+            if (lockedZoom > 0f && max > min) {
+                zoom = min + lockedZoom * (max - min);
+            } else if (session.isFront() || app.exteraless.chats.ChatsConfig.startWithWideAngleCamera.Bool()) {
+                zoom = min;
+            } else {
+                zoom = Utilities.clamp(1f, max, min);
+            }
+            session.setZoom(zoom);
         } else {
             if (cameraSession != null) {
                 cameraSession.setZoom(lockedZoom);


### PR DESCRIPTION
## Что не так

На Pixel 10 Pro (и любом устройстве, где 60 fps даётся только в 16:9) кружок с фронталки заметно уже, чем должен быть, а ползунок зума показывает на ширике «.8×» вместо штатного «1×».

Причина видна в логе HAL при записи кружка с включённым «Расширенный диапазон FPS»:

```
Front stream: 1920x1080 … requested FPS [60, 60]
TAOTIEFRONT Mode size {3840, 2160} FPS [15, 60]      ← сенсор 3840x2736, режим — вертикальный кроп
```

`CameraXSession.compareRoundPreviewSizes` ставил «умеет 60 fps» выше «не теряет угол». У Pixel все 60-fps размеры — 16:9, то есть кроп 4:3-сенсора: круг из такого кадра теряет ~21 % ширины (2160/2736). Сверху на это накладывался кроп самой фронталки: логическая камера 1 по умолчанию работает с физической 8 (3440×2448), а полный сенсор — физическая 7 (3840×2736) — доступен только как зум 0.896×.

## Что сделано

**CameraXSession**
- Угол обзора теперь сравнивается раньше 60 fps: 60 кадров берём только среди размеров с тем же углом. На Pixel вместо 1920×1080 выбирается 1440×1080 (4:3) и для фронталки, и для основной. Побочный эффект: на устройствах, где 60 fps есть только в 16:9, кружок пишется в 30 — угол важнее.
- Фронталка стартует со своего минимального зума всегда (не по настройке «Начинать с широкоугольной»): её зум ниже единицы — это не другая линза, а полный сенсор вместо кропа. Для основной камеры поведение прежнее.

**InstantCameraZoomSlider**
- Для фронталки минимальная кратность подписывается как «1×», а деления «2×/5×/10×» считаются от неё (`setDisplayNormalizationFactor` уже был в `CameraZoomSliderView`, просто не использовался). На Pixel: было `.8 · 1 · 2`, стало `1 · 2`.
- Крайняя подпись линейки не дублируется, если максимум ближе 15 % к последнему делению (иначе на фронталке Pixel рядом стоят «10» и «11»).

**Camera2Session** (тип камеры «Camera2», без CameraX)
- Зум через `CONTROL_ZOOM_RATIO` (API 30+) вместо `SCALER_CROP_REGION`: становится доступен диапазон логической камеры — ширик 0.5× на основной и полный сенсор 0.9× на фронталке. Ниже API 30 — прежний кроп.
- `getMinZoom()` возвращает реальный минимум вместо `1f`; `setZoom()` запоминает значение и до открытия камеры, чтобы стартовый запрос взял его сам.
- Дефолт кружка на Camera2: фронталка — минимум, основная — 1× (или минимум при «Начинать с широкоугольной»), как в CameraX.
- `CameraSessionWrapper` (сторис) по-прежнему живёт в 1×..max — там ничего не меняется.

**InstantCameraView**
- Шаговый зум кнопками громкости больше не упирается в 1.0 снизу — опускается до реального минимума.

Camera1 не трогал: у старого API кратности ниже единицы нет.

## Проверка

- Дамп `dumpsys media.camera` и логи HAL с Pixel 10 Pro: фронталка `zoomRatioRange [0.896, 10]`, physicalIds `[8, 7]`, все 60-fps размеры на обеих камерах — 16:9.
- Компаратор прогнан на реальной таблице размеров Pixel: старый порядок при 60 fps → 1920×1080, новый → 1440×1080 на обеих камерах.
- APK не собирал, полагаюсь на CI.

https://claude.ai/code/session_01GXf5Qw514rRaViCG3PzPdW
