### PR TITLE
feature: Add wide channel posts

### DIFF
--- a/TMessagesProj/src/main/java/app/exteraless/backup/EtgBackup.java
+++ b/TMessagesProj/src/main/java/app/exteraless/backup/EtgBackup.java
@@ -355,6 +355,7 @@ public final class EtgBackup {
         bool(list, "replaceEditedWithIcon", NaConfig.INSTANCE.getUseEditedIcon());
         bool(list, "showOnlineStatus", NaConfig.INSTANCE.getShowOnlineStatus());
         bool(list, "hideShareButton", NaConfig.INSTANCE.getHideShareButtonInChannel());
+        bool(list, "wideChannelPosts", ChatsConfig.wideChannelPosts);
         bool(list, "showResultsBeforeVoting", ChatsConfig.showResultsBeforeVoting);
         bool(list, "showCopyPhotoButton", NaConfig.INSTANCE.getShowCopyPhoto());
         bool(list, "showSaveMessageButton", NekoConfig.showAddToSavedMessages);

--- a/TMessagesProj/src/main/java/app/exteraless/chats/WideChannelPostLayout.java
+++ b/TMessagesProj/src/main/java/app/exteraless/chats/WideChannelPostLayout.java
@@ -1,0 +1,58 @@
+package app.exteraless.chats;
+
+import static org.telegram.messenger.AndroidUtilities.dp;
+
+import org.telegram.messenger.AndroidUtilities;
+
+public final class WideChannelPostLayout {
+
+    private static final int OUTER_INSET_DP = 9;
+    private static final int MEDIA_BACKGROUND_CONTENT_INSET_DP = 8;
+    private static final int REGULAR_BACKGROUND_CONTENT_INSET_DP = 17;
+
+    private WideChannelPostLayout() {
+    }
+
+    public static int backgroundWidth(int viewportWidth, int leadingInset, boolean mediaBackground) {
+        int width = viewportWidth - leadingInset - dp(OUTER_INSET_DP * 2);
+        if (mediaBackground) {
+            width -= dp(OUTER_INSET_DP);
+        }
+        return Math.max(dp(1), width);
+    }
+
+    public static int messageTextWidth(int viewportWidth, int leadingInset) {
+        return Math.max(dp(1), backgroundWidth(viewportWidth, leadingInset, false) - dp(31));
+    }
+
+    public static int mediaContentWidth(int backgroundWidth, boolean mediaBackground) {
+        int contentInset = mediaBackground
+                ? MEDIA_BACKGROUND_CONTENT_INSET_DP
+                : REGULAR_BACKGROUND_CONTENT_INSET_DP;
+        return Math.max(dp(1), backgroundWidth - dp(contentInset));
+    }
+
+    public static int mediaContentWidth(int viewportWidth, int leadingInset) {
+        return mediaContentWidth(backgroundWidth(viewportWidth, leadingInset, false), false);
+    }
+
+    public static int groupedMediaViewportWidth(int viewportWidth, int leadingInset) {
+        return Math.max(dp(1), viewportWidth - leadingInset);
+    }
+
+    public static int groupedMediaContentSpanCount() {
+        int viewportWidth = AndroidUtilities.isTablet()
+                ? AndroidUtilities.getMinTabletSide()
+                : AndroidUtilities.displaySize.x;
+        return groupedMediaContentSpanCount(viewportWidth);
+    }
+
+    public static int groupedMediaContentSpanCount(int groupedMediaViewportWidth) {
+        int viewportWidth = groupedMediaViewportWidth;
+        if (viewportWidth <= 0) {
+            return 1000;
+        }
+        int contentWidth = Math.max(dp(1), viewportWidth - dp(OUTER_INSET_DP * 2));
+        return Math.max(1, Math.min(1000, Math.round(contentWidth * 1000f / viewportWidth)));
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/chats/WideChannelPostsPreviewCell.java
+++ b/TMessagesProj/src/main/java/app/exteraless/chats/WideChannelPostsPreviewCell.java
@@ -1,0 +1,299 @@
+package app.exteraless.chats;
+
+import static org.telegram.messenger.AndroidUtilities.dp;
+import static org.telegram.messenger.LocaleController.getString;
+
+import android.animation.ValueAnimator;
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Shader;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.os.Build;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+
+import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.LocaleController;
+import org.telegram.messenger.MessageObject;
+import org.telegram.messenger.R;
+import org.telegram.messenger.SharedConfig;
+import org.telegram.messenger.UserConfig;
+import org.telegram.tgnet.TLRPC;
+import org.telegram.ui.ActionBar.BaseFragment;
+import org.telegram.ui.ActionBar.Theme;
+import org.telegram.ui.Cells.ChatMessageCell;
+import org.telegram.ui.Components.BackgroundGradientDrawable;
+import org.telegram.ui.Components.CubicBezierInterpolator;
+import org.telegram.ui.Components.MotionBackgroundDrawable;
+
+@SuppressLint("ViewConstructor")
+public class WideChannelPostsPreviewCell extends FrameLayout {
+
+    private static final int HORIZONTAL_PADDING_DP = 12;
+    private static final int VERTICAL_PADDING_DP = 10;
+
+    private final ChatMessageCell regularCell;
+    private final ChatMessageCell wideCell;
+    private final Drawable shadowDrawable;
+    private final Theme.ResourcesProvider resourcesProvider;
+
+    private BackgroundGradientDrawable.Disposable backgroundGradientDisposable;
+    private ValueAnimator animator;
+    private float progress;
+    private int previewContentWidth;
+
+    public WideChannelPostsPreviewCell(Context context, BaseFragment fragment) {
+        super(context);
+        resourcesProvider = fragment.getResourceProvider();
+        setWillNotDraw(false);
+        setClipChildren(true);
+        setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+        setContentDescription(getString(R.string.OEChatsWideChannelPosts));
+        setFocusable(false);
+        setClickable(false);
+
+        shadowDrawable = Theme.getThemedDrawable(context, R.drawable.greydivider_bottom,
+                Theme.getColor(Theme.key_windowBackgroundGrayShadow, resourcesProvider));
+
+        regularCell = createCell(context, createMessage(false));
+        wideCell = createCell(context, createMessage(true));
+        addView(regularCell);
+        addView(wideCell);
+
+        progress = ChatsConfig.wideChannelPosts.Bool() ? 1f : 0f;
+    }
+
+    private ChatMessageCell createCell(Context context, MessageObject messageObject) {
+        ChatMessageCell cell = new ChatMessageCell(context, UserConfig.selectedAccount, false, null, resourcesProvider) {
+            @Override
+            public int getParentWidth() {
+                int width = WideChannelPostsPreviewCell.this.previewContentWidth;
+                return width > 0 ? width : super.getParentWidth();
+            }
+        };
+        cell.setDelegate(new ChatMessageCell.ChatMessageCellDelegate() {
+            @Override
+            public boolean canPerformActions() {
+                return false;
+            }
+        });
+        cell.isChat = false;
+        cell.hasDiscussion = true;
+        cell.linkedChatId = 2;
+        cell.setFullyDraw(true);
+        cell.setMessageObject(messageObject, null, false, false, false);
+        return cell;
+    }
+
+    private MessageObject createMessage(boolean wide) {
+        int account = UserConfig.selectedAccount;
+        int date = (int) (System.currentTimeMillis() / 1000) - 3600;
+
+        TLRPC.TL_message message = new TLRPC.TL_message();
+        message.date = date;
+        message.dialog_id = -1;
+        message.flags = TLRPC.MESSAGE_FLAG_HAS_FROM_ID
+                | TLRPC.MESSAGE_FLAG_HAS_VIEWS
+                | TLRPC.MESSAGE_FLAG_REPLY;
+        message.id = wide ? 2 : 1;
+        message.message = getString(R.string.OEChatsWideChannelPostsPreviewText);
+        message.media = new TLRPC.TL_messageMediaEmpty();
+        message.reply_to = new TLRPC.TL_messageReplyHeader();
+        message.reply_to.flags |= 16;
+        message.reply_to.reply_to_msg_id = 10;
+        message.views = 1240;
+        message.forwards = 18;
+        message.replies = new TLRPC.TL_messageReplies();
+        message.replies.comments = true;
+        message.replies.channel_id = 2;
+        message.replies.replies = 3;
+
+        message.from_id = new TLRPC.TL_peerChannel();
+        message.from_id.channel_id = 1;
+        message.peer_id = new TLRPC.TL_peerChannel();
+        message.peer_id.channel_id = 1;
+        message.out = false;
+        message.post = true;
+
+        PreviewMessageObject messageObject = new PreviewMessageObject(account, message, wide);
+        messageObject.customReplyName = getString(R.string.OEChatsChannelPosts);
+        messageObject.replyMessageObject = createReplyMessage(account, date);
+        messageObject.viewsReloaded = true;
+        messageObject.resetLayout();
+        return messageObject;
+    }
+
+    private MessageObject createReplyMessage(int account, int date) {
+        TLRPC.TL_message reply = new TLRPC.TL_message();
+        reply.date = date - 60;
+        reply.dialog_id = -1;
+        reply.flags = TLRPC.MESSAGE_FLAG_HAS_FROM_ID;
+        reply.id = 10;
+        reply.message = getString(R.string.OEChatsWideChannelPostsPreviewReply);
+        reply.media = new TLRPC.TL_messageMediaEmpty();
+        reply.from_id = new TLRPC.TL_peerChannel();
+        reply.from_id.channel_id = 1;
+        reply.peer_id = new TLRPC.TL_peerChannel();
+        reply.peer_id.channel_id = 1;
+        reply.post = true;
+        return new MessageObject(account, reply, true, false);
+    }
+
+    public void setWide(boolean wide, boolean animated) {
+        float target = wide ? 1f : 0f;
+        if (animator != null) {
+            animator.cancel();
+            animator = null;
+        }
+        boolean canAnimate = animated && isAttachedToWindow() && getWidth() > 0
+                && SharedConfig.animationsEnabled()
+                && (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || ValueAnimator.areAnimatorsEnabled());
+        if (!canAnimate || Math.abs(progress - target) < 0.001f) {
+            progress = target;
+            invalidate();
+            return;
+        }
+        animator = ValueAnimator.ofFloat(progress, target);
+        animator.setDuration(280);
+        animator.setInterpolator(CubicBezierInterpolator.EASE_OUT_QUINT);
+        animator.addUpdateListener(valueAnimator -> {
+            progress = (float) valueAnimator.getAnimatedValue();
+            invalidate();
+        });
+        animator.start();
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int width = MeasureSpec.getSize(widthMeasureSpec);
+        int contentWidth = Math.max(dp(1), width - dp(HORIZONTAL_PADDING_DP * 2));
+        if (previewContentWidth != contentWidth) {
+            previewContentWidth = contentWidth;
+            regularCell.forceResetMessageObject();
+            wideCell.forceResetMessageObject();
+        }
+        int childWidthSpec = MeasureSpec.makeMeasureSpec(contentWidth, MeasureSpec.EXACTLY);
+        int childHeightSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED);
+        regularCell.measure(childWidthSpec, childHeightSpec);
+        wideCell.measure(childWidthSpec, childHeightSpec);
+
+        int height = dp(VERTICAL_PADDING_DP * 2)
+                + Math.max(regularCell.getMeasuredHeight(), wideCell.getMeasuredHeight());
+        setMeasuredDimension(resolveSize(width, widthMeasureSpec), resolveSize(height, heightMeasureSpec));
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        int width = right - left;
+        layoutCell(regularCell, width);
+        layoutCell(wideCell, width);
+    }
+
+    private void layoutCell(ChatMessageCell cell, int width) {
+        int left = LocaleController.isRTL
+                ? width - dp(HORIZONTAL_PADDING_DP) - cell.getMeasuredWidth()
+                : dp(HORIZONTAL_PADDING_DP);
+        int top = dp(VERTICAL_PADDING_DP);
+        cell.layout(left, top, left + cell.getMeasuredWidth(), top + cell.getMeasuredHeight());
+    }
+
+    @Override
+    protected void onDraw(@NonNull Canvas canvas) {
+        Drawable drawable = Theme.getCachedWallpaperNonBlocking();
+        if (drawable == null) {
+            canvas.drawColor(Theme.getColor(Theme.key_windowBackgroundGray, resourcesProvider));
+        } else {
+            drawable.setAlpha(255);
+            if (drawable instanceof ColorDrawable || drawable instanceof GradientDrawable || drawable instanceof MotionBackgroundDrawable) {
+                drawable.setBounds(0, 0, getMeasuredWidth(), getMeasuredHeight());
+                if (drawable instanceof BackgroundGradientDrawable backgroundGradientDrawable) {
+                    backgroundGradientDisposable = backgroundGradientDrawable.drawExactBoundsSize(canvas, this);
+                } else {
+                    drawable.draw(canvas);
+                }
+            } else if (drawable instanceof BitmapDrawable bitmapDrawable) {
+                if (bitmapDrawable.getTileModeX() == Shader.TileMode.REPEAT) {
+                    canvas.save();
+                    float scale = 2f / AndroidUtilities.density;
+                    canvas.scale(scale, scale);
+                    drawable.setBounds(0, 0,
+                            (int) Math.ceil(getMeasuredWidth() / scale),
+                            (int) Math.ceil(getMeasuredHeight() / scale));
+                } else {
+                    float scale = Math.max(
+                            getMeasuredWidth() / (float) drawable.getIntrinsicWidth(),
+                            getMeasuredHeight() / (float) drawable.getIntrinsicHeight());
+                    int width = (int) Math.ceil(drawable.getIntrinsicWidth() * scale);
+                    int height = (int) Math.ceil(drawable.getIntrinsicHeight() * scale);
+                    int x = (getMeasuredWidth() - width) / 2;
+                    int y = (getMeasuredHeight() - height) / 2;
+                    canvas.save();
+                    canvas.clipRect(0, 0, getMeasuredWidth(), getMeasuredHeight());
+                    drawable.setBounds(x, y, x + width, y + height);
+                }
+                drawable.draw(canvas);
+                canvas.restore();
+            }
+        }
+        shadowDrawable.setBounds(0, 0, getMeasuredWidth(), getMeasuredHeight());
+        shadowDrawable.draw(canvas);
+    }
+
+    @Override
+    protected void dispatchDraw(@NonNull Canvas canvas) {
+        long drawingTime = getDrawingTime();
+        if (progress < 1f) {
+            drawChild(canvas, regularCell, drawingTime);
+        }
+        if (progress <= 0f) {
+            return;
+        }
+        if (progress >= 1f) {
+            drawChild(canvas, wideCell, drawingTime);
+            return;
+        }
+        int revealWidth = Math.round(getWidth() * progress);
+        canvas.save();
+        if (LocaleController.isRTL) {
+            canvas.clipRect(0, 0, revealWidth, getHeight());
+        } else {
+            canvas.clipRect(getWidth() - revealWidth, 0, getWidth(), getHeight());
+        }
+        drawChild(canvas, wideCell, drawingTime);
+        canvas.restore();
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        if (animator != null) {
+            animator.cancel();
+            animator = null;
+        }
+        if (backgroundGradientDisposable != null) {
+            backgroundGradientDisposable.dispose();
+            backgroundGradientDisposable = null;
+        }
+        super.onDetachedFromWindow();
+    }
+
+    private static final class PreviewMessageObject extends MessageObject {
+
+        private final boolean wide;
+
+        PreviewMessageObject(int account, TLRPC.Message message, boolean wide) {
+            super(account, message, true, false);
+            this.wide = wide;
+        }
+
+        @Override
+        public boolean isWideChannelPost() {
+            return wide;
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraChatsActivity.java
+++ b/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraChatsActivity.java
@@ -6,9 +6,6 @@ import static org.telegram.messenger.LocaleController.getString;
 import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.graphics.Canvas;
-import android.graphics.Paint;
-import android.text.TextPaint;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -25,7 +22,6 @@ import org.telegram.messenger.ApplicationLoader;
 import org.telegram.messenger.LocaleController;
 import org.telegram.messenger.MessagesController;
 import org.telegram.messenger.R;
-import org.telegram.messenger.SharedConfig;
 import org.telegram.ui.ActionBar.ActionBarMenuItem;
 import org.telegram.ui.ActionBar.AlertDialog;
 import org.telegram.ui.ActionBar.Theme;
@@ -48,9 +44,10 @@ import java.util.Locale;
 
 import app.exteraless.OpenExteraConfig;
 import app.exteraless.chats.ChatsConfig;
-import app.exteraless.icons.BaseIconPacks;
 import app.exteraless.chats.DoubleTapCell;
 import app.exteraless.chats.StickerShapeCell;
+import app.exteraless.chats.WideChannelPostsPreviewCell;
+import app.exteraless.icons.BaseIconPacks;
 import kotlin.Unit;
 import tw.nekomimi.nekogram.NekoConfig;
 import tw.nekomimi.nekogram.config.ConfigItem;
@@ -80,6 +77,7 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
     private static final int TYPE_EXPANDABLE_SWITCH = 104;
     /** Круглая галочка внутри группы. */
     private static final int TYPE_ROUND_CHECK = 105;
+    private static final int TYPE_WIDE_CHANNEL_PREVIEW = 106;
 
     /** Размер стикеров по умолчанию: к нему возвращает кнопка сброса в шапке. */
     private static final float STICKER_SIZE_DEFAULT = 14.0f;
@@ -87,6 +85,7 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
     private StickerSizeCell stickerSizeCell;
     private StickerShapeCell stickerShapeCell;
     private DoubleTapCell doubleTapCell;
+    private WideChannelPostsPreviewCell wideChannelPostsPreviewCell;
     private ActionBarMenuItem resetItem;
 
     private boolean repliesExpanded;
@@ -196,6 +195,11 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
     private int actionBarForwardRow;
     private int groupedMessageMenuRow;
     private int messagesDividerRow;
+
+    private int channelPostsHeaderRow;
+    private int wideChannelPostsPreviewRow;
+    private int wideChannelPostsRow;
+    private int channelPostsDividerRow;
 
     // Camera
     private int cameraHeaderRow;
@@ -366,6 +370,11 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
         }
         groupedMessageMenuRow = addRow("groupedMessageMenu");
         messagesDividerRow = addRow();
+
+        channelPostsHeaderRow = addRow("channelPostsHeader");
+        wideChannelPostsPreviewRow = addRow("wideChannelPostsPreview");
+        wideChannelPostsRow = addRow("wideChannelPosts");
+        channelPostsDividerRow = addRow();
 
         cameraHeaderRow = addRow("cameraHeader");
         cameraTypeRow = addRow("cameraType");
@@ -1108,6 +1117,11 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
             rebuildChats();
         } else if (position == showResultsBeforeVotingRow) {
             rebuildChats();
+        } else if (position == wideChannelPostsRow) {
+            if (wideChannelPostsPreviewCell != null) {
+                wideChannelPostsPreviewCell.setWide(value, true);
+            }
+            rebuildChats();
         }
     }
 
@@ -1256,6 +1270,7 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
         if (position == actionBarCopyRow) return NaConfig.INSTANCE.getActionBarButtonCopy();
         if (position == actionBarForwardRow) return NaConfig.INSTANCE.getActionBarButtonForward();
         if (position == groupedMessageMenuRow) return NaConfig.INSTANCE.getGroupedMessageMenu();
+        if (position == wideChannelPostsRow) return ChatsConfig.wideChannelPosts;
         if (position == extendedFpsRow) return ChatsConfig.extendedFramesPerSecond;
         if (position == cameraStabilizationRow) return ChatsConfig.cameraStabilization;
         if (position == cameraMirrorModeRow) return ChatsConfig.cameraMirrorMode;
@@ -1411,6 +1426,11 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
                     doubleTapCell = new DoubleTapCell(mContext);
                     view = doubleTapCell;
                     break;
+                case TYPE_WIDE_CHANNEL_PREVIEW:
+                    wideChannelPostsPreviewCell = new WideChannelPostsPreviewCell(mContext,
+                            OpenExteraChatsActivity.this);
+                    view = wideChannelPostsPreviewCell;
+                    break;
                 case TYPE_SET_REACTION:
                     view = new DoubleTapCell.SetReactionCell(mContext);
                     break;
@@ -1438,7 +1458,8 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
         @Override
         public boolean isEnabled(RecyclerView.ViewHolder holder) {
             int type = holder.getItemViewType();
-            if (type == TYPE_STICKER_SIZE || type == TYPE_STICKER_SHAPE || type == TYPE_DOUBLE_TAP) {
+            if (type == TYPE_STICKER_SIZE || type == TYPE_STICKER_SHAPE || type == TYPE_DOUBLE_TAP
+                    || type == TYPE_WIDE_CHANNEL_PREVIEW) {
                 return false;
             }
             if (type == TYPE_SET_REACTION || type == TYPE_EXPANDABLE_SWITCH || type == TYPE_ROUND_CHECK) {
@@ -1453,7 +1474,8 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
          */
         @Override
         protected boolean isSectionContent(int viewType) {
-            if (viewType == TYPE_EXPANDABLE_SWITCH || viewType == TYPE_ROUND_CHECK) {
+            if (viewType == TYPE_EXPANDABLE_SWITCH || viewType == TYPE_ROUND_CHECK
+                    || viewType == TYPE_WIDE_CHANNEL_PREVIEW) {
                 return true;
             }
             return super.isSectionContent(viewType);
@@ -1464,6 +1486,10 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
             switch (holder.getItemViewType()) {
                 case TYPE_SET_REACTION:
                     ((DoubleTapCell.SetReactionCell) holder.itemView).update(false);
+                    break;
+                case TYPE_WIDE_CHANNEL_PREVIEW:
+                    ((WideChannelPostsPreviewCell) holder.itemView)
+                            .setWide(ChatsConfig.wideChannelPosts.Bool(), false);
                     break;
                 case TYPE_HEADER:
                     bindHeader((HeaderCell) holder.itemView, position);
@@ -1500,6 +1526,8 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
                 cell.setText(getString(R.string.OpenExteraChats));
             } else if (position == messagesHeaderRow) {
                 cell.setText(getString(R.string.OEChatsMessages));
+            } else if (position == channelPostsHeaderRow) {
+                cell.setText(getString(R.string.OEChatsChannelPosts));
             } else if (position == cameraHeaderRow) {
                 cell.setText(getString(R.string.VoipCamera));
             } else if (position == photoHeaderRow) {
@@ -1708,6 +1736,9 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
                 cell.setTextAndValueAndCheck(getString(R.string.OEChatsShowResultsBeforeVoting),
                         getString(R.string.OEChatsShowResultsBeforeVotingInfo),
                         ChatsConfig.showResultsBeforeVoting.Bool(), true, true);
+            } else if (position == wideChannelPostsRow) {
+                cell.setTextAndCheck(getString(R.string.OEChatsWideChannelPosts),
+                        ChatsConfig.wideChannelPosts.Bool(), false, true);
             } else if (position == groupedMessageMenuRow) {
                 cell.setTextAndCheck(getString(R.string.GroupedMessageMenu), NaConfig.INSTANCE.getGroupedMessageMenu().Bool(), false);
             } else if (position == rememberLastUsedCameraRow) {
@@ -1786,6 +1817,8 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
                 cell.setText(getString(R.string.OEChatsHideReactionsInfo));
             } else if (position == messagesDividerRow) {
                 cell.setText(getString(R.string.OEChatsGlassMessageMenuInfo));
+            } else if (position == channelPostsDividerRow) {
+                cell.setText(getString(R.string.OEChatsWideChannelPostsFooter));
             } else if (position == cameraDividerRow) {
                 cell.setText(getString(R.string.OEChatsStaticZoomInfo));
             } else if (position == photoDividerRow) {
@@ -1805,6 +1838,7 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
             if (position == stickerSizeRow) return TYPE_STICKER_SIZE;
             if (position == stickerShapeRow) return TYPE_STICKER_SHAPE;
             if (position == doubleTapRow) return TYPE_DOUBLE_TAP;
+            if (position == wideChannelPostsPreviewRow) return TYPE_WIDE_CHANNEL_PREVIEW;
             if (position == doubleTapReactionRow) return TYPE_SET_REACTION;
             if (isHeader(position)) return TYPE_HEADER;
             if (isDivider(position)) return TYPE_INFO_PRIVACY;
@@ -1819,6 +1853,7 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
             return position == stickerShapeHeaderRow
                     || position == stickersHeaderRow || position == doubleTapHeaderRow
                     || position == chatsHeaderRow || position == messagesHeaderRow
+                    || position == channelPostsHeaderRow
                     || position == cameraHeaderRow
                     || position == photoHeaderRow || position == videosHeaderRow;
         }
@@ -1828,6 +1863,7 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
                     || position == linksDividerRow || position == stickersDividerRow
                     || position == doubleTapDividerRow || position == chatsDividerRow
                     || position == messagesDividerRow
+                    || position == channelPostsDividerRow
                     || position == cameraDividerRow || position == photoDividerRow
                     || position == videosDividerRow;
         }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessageObject.java
@@ -359,6 +359,7 @@ public class MessageObject {
     private int generatedWithMinSize;
     private float generatedWithDensity;
     private float generatedWithFontSize;
+    private boolean generatedWithWideChannelPosts;
     public boolean wasJustSent;
     public boolean isBotPendingDraft;
 
@@ -1332,6 +1333,8 @@ public class MessageObject {
         }
 
         private int maxSizeWidth = 800;
+        private boolean calculatedForWideChannelPosts;
+        private int calculatedForWideChannelPostsSpanCount;
 
         public final TransitionParams transitionParams = new TransitionParams();
 
@@ -1364,18 +1367,97 @@ public class MessageObject {
             return maxSizeWidth / sum;
         }
 
+        private float getMediaAspectRatio(MessageObject messageObject) {
+            TLRPC.PhotoSize photoSize = FileLoader.getClosestPhotoSizeWithSize(messageObject.photoThumbs, AndroidUtilities.getPhotoSize());
+            if (photoSize != null && photoSize.w > 0 && photoSize.h > 0) {
+                return photoSize.w / (float) photoSize.h;
+            }
+            if (messageObject.hasExtendedMediaPreview()) {
+                TLRPC.MessageExtendedMedia media = messageObject.messageOwner.media.extended_media.get(0);
+                if (media instanceof TLRPC.TL_messageExtendedMediaPreview) {
+                    TLRPC.TL_messageExtendedMediaPreview preview = (TLRPC.TL_messageExtendedMediaPreview) media;
+                    if (preview.w > 0 && preview.h > 0) {
+                        return preview.w / (float) preview.h;
+                    }
+                }
+            }
+            TLRPC.Document document = messageObject.getDocument();
+            if (document != null) {
+                for (int i = 0; i < document.attributes.size(); i++) {
+                    TLRPC.DocumentAttribute attribute = document.attributes.get(i);
+                    if ((attribute instanceof TLRPC.TL_documentAttributeVideo
+                            || attribute instanceof TLRPC.TL_documentAttributeImageSize)
+                            && attribute.w > 0 && attribute.h > 0) {
+                        return attribute.w / (float) attribute.h;
+                    }
+                }
+            }
+            return 1f;
+        }
+
+        private void fillWideSiblingLayout(int targetWidth, boolean isOut) {
+            GroupedMessagePosition sibling = null;
+            for (int i = 0; i < posArray.size(); i++) {
+                GroupedMessagePosition position = posArray.get(i);
+                if (position.siblingHeights != null) {
+                    sibling = position;
+                    break;
+                }
+            }
+            if (sibling == null) {
+                return;
+            }
+
+            int adjacentWidth = 0;
+            for (int i = 0; i < posArray.size(); i++) {
+                GroupedMessagePosition position = posArray.get(i);
+                if (position != sibling) {
+                    adjacentWidth = Math.max(adjacentWidth, position.pw);
+                }
+            }
+            int remaining = targetWidth - sibling.pw - adjacentWidth;
+            if (remaining <= 0) {
+                return;
+            }
+
+            if (isOut) {
+                sibling.pw += remaining;
+            } else {
+                for (int i = 0; i < posArray.size(); i++) {
+                    GroupedMessagePosition position = posArray.get(i);
+                    if (position != sibling) {
+                        position.pw += remaining;
+                    }
+                }
+            }
+        }
+
         public boolean reversed;
 
         public void calculate() {
+            calculate(0);
+        }
+
+        private void calculate(int groupedMediaViewportWidth) {
             posArray.clear();
             positions.clear();
             positionsArray.clear();
             captionMessage = null;
-
-            maxSizeWidth = 800;
-            int firstSpanAdditionalSize = 200;
+            cachedWidthForCaption = -1;
 
             int count = messages.size();
+            MessageObject firstMessage = count > 0 ? messages.get(reversed ? count - 1 : 0) : null;
+            boolean wideChannelPost = firstMessage != null && firstMessage.isWideChannelPost();
+            calculatedForWideChannelPosts = wideChannelPost;
+            if (wideChannelPost) {
+                maxSizeWidth = groupedMediaViewportWidth > 0
+                        ? app.exteraless.chats.WideChannelPostLayout.groupedMediaContentSpanCount(groupedMediaViewportWidth)
+                        : app.exteraless.chats.WideChannelPostLayout.groupedMediaContentSpanCount();
+            } else {
+                maxSizeWidth = 800;
+            }
+            calculatedForWideChannelPostsSpanCount = maxSizeWidth;
+            int firstSpanAdditionalSize = 1000 - maxSizeWidth;
             if (count == 1) {
                 captionMessage = messages.get(0);
                 return;
@@ -1414,10 +1496,9 @@ public class MessageObject {
                 if (messageObject.messageOwner != null && messageObject.messageOwner.invert_media) {
                     captionAbove = true;
                 }
-                TLRPC.PhotoSize photoSize = FileLoader.getClosestPhotoSizeWithSize(messageObject.photoThumbs, AndroidUtilities.getPhotoSize());
                 GroupedMessagePosition position = new GroupedMessagePosition();
                 position.last = (reversed ? a == 0 : a == count - 1);
-                position.aspectRatio = photoSize == null ? 1.0f : photoSize.w / (float) photoSize.h;
+                position.aspectRatio = getMediaAspectRatio(messageObject);
 
                 if (position.aspectRatio > 1.2f) {
                     proportions.append("w");
@@ -1479,7 +1560,7 @@ public class MessageObject {
                 return;
             }
 
-            if (needShare) {
+            if (needShare && !wideChannelPost) {
                 maxSizeWidth -= 50;
                 firstSpanAdditionalSize += 50;
             }
@@ -1744,6 +1825,10 @@ public class MessageObject {
                     y += lineHeight;
                 }
             }
+            if (wideChannelPost && hasSibling) {
+                fillWideSiblingLayout(maxSizeWidth, isOut);
+            }
+
             int avatarOffset = 108;
             for (int a = 0; a < count; a++) {
                 GroupedMessagePosition pos = posArray.get(a);
@@ -1763,7 +1848,7 @@ public class MessageObject {
                     }
                 }
                 MessageObject messageObject = messages.get(a);
-                if (!isOut && messageObject.needDrawAvatarInternal()) {
+                if (!wideChannelPost && !isOut && messageObject.needDrawAvatarInternal()) {
                     if (pos.edge) {
                         if (pos.spanSize != 1000) {
                             pos.spanSize += avatarOffset;
@@ -1777,6 +1862,29 @@ public class MessageObject {
                         }
                     }
                 }
+            }
+        }
+
+        public void ensureLayoutFor(MessageObject messageObject) {
+            ensureLayoutFor(messageObject, 0);
+        }
+
+        public void ensureLayoutFor(MessageObject messageObject, int groupedMediaViewportWidth) {
+            if (messageObject == null) {
+                return;
+            }
+            boolean wideChannelPost = messageObject.isWideChannelPost();
+            int expectedSpanCount;
+            if (wideChannelPost) {
+                expectedSpanCount = groupedMediaViewportWidth > 0
+                        ? app.exteraless.chats.WideChannelPostLayout.groupedMediaContentSpanCount(groupedMediaViewportWidth)
+                        : app.exteraless.chats.WideChannelPostLayout.groupedMediaContentSpanCount();
+            } else {
+                expectedSpanCount = 800;
+            }
+            if (calculatedForWideChannelPosts != wideChannelPost
+                    || calculatedForWideChannelPostsSpanCount != expectedSpanCount) {
+                calculate(groupedMediaViewportWidth);
             }
         }
 
@@ -6894,7 +7002,10 @@ public class MessageObject {
         if (layoutCreated) {
             int newMinSize = AndroidUtilities.isTablet() ? AndroidUtilities.getMinTabletSide() : AndroidUtilities.displaySize.x;
             float newFontSize = Theme.chat_msgTextPaint != null ? Theme.chat_msgTextPaint.getTextSize() : 0;
-            if (Math.abs(generatedWithMinSize - newMinSize) > dp(52) || generatedWithDensity != AndroidUtilities.density || generatedWithFontSize != newFontSize) {
+            if (Math.abs(generatedWithMinSize - newMinSize) > dp(52)
+                    || generatedWithDensity != AndroidUtilities.density
+                    || generatedWithFontSize != newFontSize
+                    || generatedWithWideChannelPosts != isWideChannelPost()) {
                 layoutCreated = false;
             }
         }
@@ -8582,6 +8693,7 @@ public class MessageObject {
     public boolean sideMenuEnabled;
     public int getMaxMessageTextWidth() {
         int maxWidth = 0;
+        final boolean wideChannelPost = isWideChannelPost();
         if (AndroidUtilities.isTablet() && eventId != 0) {
             generatedWithMinSize = dp(530);
         } else {
@@ -8589,11 +8701,19 @@ public class MessageObject {
         }
         generatedWithDensity = AndroidUtilities.density;
         generatedWithFontSize = Theme.chat_msgTextPaint != null ? Theme.chat_msgTextPaint.getTextSize() : 0;
-        if (hasCode && !isSaved) {
+        generatedWithWideChannelPosts = wideChannelPost;
+        final boolean needDrawAvatarInternal = needDrawAvatarInternal();
+        if (wideChannelPost) {
+            int leadingInset = sideMenuEnabled
+                    ? dp(64)
+                    : needDrawAvatarInternal && !isOutOwner() && !messageOwner.isThreadMessage ? dp(52) : 0;
+            maxWidth = app.exteraless.chats.WideChannelPostLayout.messageTextWidth(
+                    generatedWithMinSize, leadingInset);
+        } else if (hasCode && !isSaved) {
             maxWidth = generatedWithMinSize - dp(45 + 15);
             if (sideMenuEnabled) {
                 maxWidth -= dp(64);
-            } else if (needDrawAvatarInternal() && !isOutOwner() && !messageOwner.isThreadMessage) {
+            } else if (needDrawAvatarInternal && !isOutOwner() && !messageOwner.isThreadMessage) {
                 maxWidth -= dp(52);
             }
         } else if (getMedia(messageOwner) instanceof TLRPC.TL_messageMediaWebPage && getMedia(messageOwner).webpage != null && "telegram_background".equals(getMedia(messageOwner).webpage.type)) {
@@ -8610,7 +8730,6 @@ public class MessageObject {
             maxWidth = dp(200);
         }
         if (maxWidth == 0) {
-            final boolean needDrawAvatarInternal = needDrawAvatarInternal();
             maxWidth = generatedWithMinSize - dp(type == TYPE_ARTICLE ? 40 : 80);
             if (sideMenuEnabled) {
                 maxWidth -= dp(64);
@@ -8624,7 +8743,7 @@ public class MessageObject {
                 maxWidth -= dp(10);
             }
         }
-        if (emojiOnlyCount >= 1 && totalAnimatedEmojiCount <= 100 && (emojiOnlyCount - totalAnimatedEmojiCount) < (SharedConfig.getDevicePerformanceClass() >= SharedConfig.PERFORMANCE_CLASS_HIGH ? 100 : 50) && (hasValidReplyMessageObject() || isForwarded())) {
+        if (!wideChannelPost && emojiOnlyCount >= 1 && totalAnimatedEmojiCount <= 100 && (emojiOnlyCount - totalAnimatedEmojiCount) < (SharedConfig.getDevicePerformanceClass() >= SharedConfig.PERFORMANCE_CLASS_HIGH ? 100 : 50) && (hasValidReplyMessageObject() || isForwarded())) {
             maxWidth = Math.min(maxWidth, (int) (generatedWithMinSize * .65f));
         }
         return maxWidth;
@@ -9959,6 +10078,24 @@ public class MessageObject {
             return true;
         }
         return false;
+    }
+
+    public boolean isWideChannelPost() {
+        if (!app.exteraless.chats.ChatsConfig.wideChannelPosts()
+                || messageOwner == null
+                || messageOwner.action != null
+                || messageOwner.peer_id == null
+                || messageOwner.peer_id.channel_id == 0
+                || eventId != 0
+                || preview
+                || sendPreview
+                || previewForward
+                || isRepostPreview
+                || isSponsored()) {
+            return false;
+        }
+        TLRPC.Chat chat = getChat(null, null, messageOwner.peer_id.channel_id);
+        return chat != null ? ChatObject.isChannelAndNotMegaGroup(chat) : messageOwner.post;
     }
 
     public boolean isFromGroup() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -125,6 +125,7 @@ import org.telegram.messenger.LiteMode;
 import org.telegram.messenger.LocaleController;
 import org.telegram.messenger.MediaController;
 import org.telegram.messenger.MediaDataController;
+import app.exteraless.chats.WideChannelPostLayout;
 import app.exteraless.feed.FeedMessageUtils;
 import org.telegram.messenger.MessageObject;
 import org.telegram.messenger.MessagesController;
@@ -6864,6 +6865,11 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     public MultiLayoutTypingAnimator botDraftTypingAnimator;
 
     private void setMessageContent(MessageObject messageObject, MessageObject.GroupedMessages groupedMessages, boolean bottomNear, boolean topNear, boolean firstInChat, boolean lastInChatList) {
+        if (groupedMessages != null) {
+            int groupedMediaViewportWidth = WideChannelPostLayout.groupedMediaViewportWidth(
+                    getGroupPhotosBaseWidth(messageObject), getWideChannelPostLeadingInset(messageObject));
+            groupedMessages.ensureLayoutFor(messageObject, groupedMediaViewportWidth);
+        }
         if (messageObject.checkLayout() || currentPosition != null && lastHeight != AndroidUtilities.displaySize.y) {
             currentMessageObject = null;
         }
@@ -7089,6 +7095,11 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
             }
             drawSummarizeButton = !app.exteraless.appearance.AiFeaturesHelper.isMessageSummaryHidden() && TranslateController.isSummarizable(messageObject);
+            if (messageObject.isWideChannelPost()) {
+                drawSideButton = 0;
+                drawSideButton2 = 0;
+                drawSummarizeButton = false;
+            }
             hasReplyQuote = false;
             isReplyQuote = false;
             isReplyTaskOrPollOption = false;
@@ -7504,6 +7515,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 } else {
                     maxWidth = Math.min(getParentWidth(), AndroidUtilities.displaySize.y) - dp((isArticle ? 40 : 80) + (isSideMenuEnabled ? ChatActivity.SIDE_MENU_WIDTH : drawAvatar ? 42 : 0));
                 }
+                int wideBackgroundWidth = getWideChannelPostBackgroundWidth(messageObject);
+                if (!isArticle && wideBackgroundWidth != 0) {
+                    maxWidth = wideBackgroundWidth - dp(31);
+                }
                 drawName = drawAvatar || isPinnedChat || isSavedChat && !messageObject.isOutOwner() && (messageObject.getSavedDialogId() < 0 || messageObject.getSavedDialogId() == UserObject.ANONYMOUS) || (messageObject.messageOwner.peer_id != null && messageObject.messageOwner.peer_id.channel_id != 0 && (!messageObject.isOutOwner() || messageObject.isSupergroup())) || messageObject.isImportedForward() && messageObject.messageOwner.fwd_from.from_id == null;
 
                 availableTimeWidth = maxWidth;
@@ -7900,6 +7915,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 if (commentLayout != null && drawSideButton != 3) {
                     maxChildWidth = Math.max(maxChildWidth, totalCommentWidth);
                 }
+                if (wideBackgroundWidth != 0) {
+                    maxChildWidth = Math.max(maxChildWidth, wideBackgroundWidth - dp(31));
+                }
                 int maxWebWidth = 0;
 
                 if (hasLinkPreview || hasGamePreview || hasInvoicePreview) {
@@ -7910,6 +7928,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         linkPreviewMaxWidth = AndroidUtilities.getMinTabletSide() - dp(80 + (isSideMenued ? 68 : drawAvatar ? 52 : 0));
                     } else {
                         linkPreviewMaxWidth = getParentWidth() - dp(80 + (isSideMenued ? 68 : drawAvatar ? 52 : 0));
+                    }
+                    if (wideBackgroundWidth != 0) {
+                        linkPreviewMaxWidth = wideBackgroundWidth - dp(41);
                     }
                     if (drawSideButton != 0) {
                         linkPreviewMaxWidth -= dp(currentMessageObject.isSaved && currentMessageObject.isOutOwner() ? 25 : 20);
@@ -8028,7 +8049,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         }
                         type = webPage.type;
                         duration = webPage.duration;
-                        if (site_name != null && photo != null && site_name.toString().toLowerCase().equals("instagram")) {
+                        if (wideBackgroundWidth == 0
+                                && site_name != null
+                                && photo != null
+                                && site_name.toString().toLowerCase().equals("instagram")) {
                             linkPreviewMaxWidth = Math.max(AndroidUtilities.displaySize.y / 3, currentMessageObject.textWidth);
                         }
                         final boolean isSmallImageType = isSmallImageLinkPreviewType(type);
@@ -8638,7 +8662,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             } else if (documentAttachType == DOCUMENT_ATTACH_TYPE_ROUND) {
                                 maxPhotoWidth = AndroidUtilities.roundMessageSize;
                                 photoImage.setAllowDecodeSingleFrame(true);
-                            } else if (documentAttachType == DOCUMENT_ATTACH_TYPE_STORY) {
+                            } else if (documentAttachType == DOCUMENT_ATTACH_TYPE_STORY && wideBackgroundWidth == 0) {
                                 maxPhotoWidth /= 2;
                             }
                             if (hasInvoicePreview && maxPhotoWidth < messageObject.textWidth) {
@@ -8962,6 +8986,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 } else {
                     backgroundWidth = Math.min(getParentWidth() - dp(50 + (isSideMenued ? ChatActivity.SIDE_MENU_WIDTH : drawAvatar ? 52 : 0)), dp(270));
                 }
+                backgroundWidth = applyWideChannelPostWidth(messageObject, backgroundWidth);
                 availableTimeWidth = backgroundWidth - dp(31);
 
                 int maxWidth = getMaxNameWidth() - dp(50);
@@ -9074,6 +9099,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 } else {
                     backgroundWidth = Math.min(getParentWidth() - dp(50 + (isSideMenued ? ChatActivity.SIDE_MENU_WIDTH : drawAvatar ? 52 : 0)), dp(270));
                 }
+                backgroundWidth = applyWideChannelPostWidth(messageObject, backgroundWidth);
                 availableTimeWidth = backgroundWidth - dp(31);
 
                 long uid = MessageObject.getMedia(messageObject.messageOwner).user_id;
@@ -9180,7 +9206,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 } else {
                     backgroundWidth = maxWidth = Math.min(getParentWidth() - dp(50 + (isSideMenued ? ChatActivity.SIDE_MENU_WIDTH : drawAvatar ? 52 : 0)), dp(270));
                 }
+                backgroundWidth = maxWidth = applyWideChannelPostWidth(messageObject, backgroundWidth);
                 createDocumentLayout(backgroundWidth, messageObject);
+                backgroundWidth = applyWideChannelPostWidth(messageObject, backgroundWidth);
 
                 setMessageObjectInternal(messageObject);
 
@@ -9227,7 +9255,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
                 if (currentPosition != null) {
                     backgroundWidth = maxWidth;
+                } else {
+                    backgroundWidth = applyWideChannelPostWidth(messageObject, backgroundWidth);
+                    maxWidth = Math.max(maxWidth, backgroundWidth);
                 }
+                backgroundWidth = applyWideChannelPostWidth(messageObject, backgroundWidth);
+                maxWidth = Math.max(maxWidth, backgroundWidth);
 
                 int durationWidth = createDocumentLayout(maxWidth, messageObject);
 
@@ -9279,7 +9312,8 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 if (groupMedia == null) {
                     groupMedia = new GroupMedia(this);
                 }
-                groupMedia.setOverrideWidth(-1);
+                int widePaidMediaWidth = getWideChannelPostMediaWidth(messageObject);
+                groupMedia.setOverrideWidth(widePaidMediaWidth == 0 ? -1 : widePaidMediaWidth);
                 groupMedia.setMessageObject(messageObject, pinnedBottom, pinnedTop);
                 backgroundWidth = groupMedia.width + dp(8 + 9);
                 availableTimeWidth = backgroundWidth - dp(31);
@@ -9292,6 +9326,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 if (timeWidthTotal > backgroundWidth) {
                     backgroundWidth = timeWidthTotal;
                     groupMedia.setOverrideWidth(backgroundWidth - dp(8 + 9));
+                }
+                if (widePaidMediaWidth != 0) {
+                    backgroundWidth = getWideChannelPostBackgroundWidth(messageObject);
+                    groupMedia.setOverrideWidth(widePaidMediaWidth);
                 }
                 mediaBackground = false;
 
@@ -9455,10 +9493,14 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             backgroundWidth -= dp(20);
                         }
                     }
+                    backgroundWidth = applyWideChannelPostWidth(messageObject, backgroundWidth);
                     int maxTextWidth = 0;
                     int maxWidth = backgroundWidth - dp(86 + (currentPosition == null ? 0 : 52));
                     if (currentPosition == null) {
                         captionFullWidth = backgroundWidth - getExtraTextX() * 2;
+                        if (messageObject.isWideChannelPost()) {
+                            captionFullWidth -= dp(45);
+                        }
                         currentCaption = messageObject.caption;
                         if (!TextUtils.isEmpty(currentCaption)) {
                             try {
@@ -9580,6 +9622,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         if (checkNeedDrawShareButton(messageObject)) {
                             backgroundWidth -= dp(20);
                         }
+                        backgroundWidth = applyWideChannelPostWidth(messageObject, backgroundWidth);
                         int maxWidth = backgroundWidth - dp(37);
                         availableTimeWidth = maxWidth;
                         maxWidth -= dp(54);
@@ -9603,6 +9646,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             scheduledInvalidate = true;
                         } else {
                             backgroundWidth -= dp(9);
+                            backgroundWidth = applyWideChannelPostWidth(messageObject, backgroundWidth);
                         }
                         docTitleLayout = new StaticLayout(TextUtils.ellipsize(getString("AttachLiveLocation", R.string.AttachLiveLocation), Theme.chat_locationTitlePaint, maxWidth, TextUtils.TruncateAt.END), Theme.chat_locationTitlePaint, maxWidth + dp(2), Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, false);
 
@@ -9630,6 +9674,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         if (checkNeedDrawShareButton(messageObject)) {
                             backgroundWidth -= dp(20);
                         }
+                        backgroundWidth = applyWideChannelPostWidth(messageObject, backgroundWidth);
                         int maxWidth = backgroundWidth - dp(34);
                         availableTimeWidth = maxWidth;
 
@@ -9664,6 +9709,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         if (checkNeedDrawShareButton(messageObject)) {
                             backgroundWidth -= dp(20);
                         }
+                        backgroundWidth = applyWideChannelPostWidth(messageObject, backgroundWidth);
                         availableTimeWidth = backgroundWidth - dp(34);
 
                         photoWidth = backgroundWidth - dp(8);
@@ -9938,11 +9984,17 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     currentPhotoObject = FileLoader.getClosestPhotoSizeWithSize(messageObject.photoThumbs, AndroidUtilities.getPhotoSize(true));
                     photoParentObject = messageObject.photoThumbsObject;
                     boolean useFullWidth = false;
+                    boolean useWideChannelWidth = false;
                     if (messageObject.type == MessageObject.TYPE_ROUND_VIDEO) {
                         documentAttach = messageObject.getDocument();
                         documentAttachType = DOCUMENT_ATTACH_TYPE_ROUND;
                     } else {
-                        if (AndroidUtilities.isTablet()) {
+                        int wideMediaWidth = getWideChannelPostMediaWidth(messageObject);
+                        if (wideMediaWidth != 0) {
+                            photoWidth = wideMediaWidth;
+                            useFullWidth = true;
+                            useWideChannelWidth = true;
+                        } else if (AndroidUtilities.isTablet()) {
                             photoWidth = (int) (AndroidUtilities.getMinTabletSide() * 0.7f);
                         } else {
                             if (
@@ -9971,11 +10023,14 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         if (photoHeight > AndroidUtilities.getPhotoSize()) {
                             photoHeight = AndroidUtilities.getPhotoSize();
                         }
-                    } else if (currentMessageObject != null && !currentMessageObject.isOutOwner() && isSideMenuPossibleLeftMargin()) {
+                    } else if (!useWideChannelWidth
+                            && currentMessageObject != null
+                            && !currentMessageObject.isOutOwner()
+                            && isSideMenuPossibleLeftMargin()) {
                         photoWidth -= dp(ChatActivity.SIDE_MENU_WIDTH);
-                    } else if (isSideMenuEnabled) {
+                    } else if (!useWideChannelWidth && isSideMenuEnabled) {
                         photoWidth -= dp(ChatActivity.SIDE_MENU_WIDTH);
-                    } else if (drawAvatar) {
+                    } else if (!useWideChannelWidth && drawAvatar) {
                         photoWidth -= dp(52);
                     }
 
@@ -10018,15 +10073,34 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                                 imageW = preview.thumb.w;
                                 imageH = preview.thumb.h;
                             }
-                        } else if (size != null && !(size instanceof TLRPC.TL_photoStrippedSize)) {
-                            imageW = size.w;
-                            imageH = size.h;
-                        } else if (documentAttach != null) {
+                        } else {
+                            if (documentAttach != null
+                                    && (messageObject.type == MessageObject.TYPE_VIDEO
+                                    || messageObject.type == MessageObject.TYPE_GIF)) {
+                                for (int a = 0, N = documentAttach.attributes.size(); a < N; a++) {
+                                    TLRPC.DocumentAttribute attribute = documentAttach.attributes.get(a);
+                                    if ((attribute instanceof TLRPC.TL_documentAttributeVideo
+                                            || attribute instanceof TLRPC.TL_documentAttributeImageSize)
+                                            && attribute.w > 0 && attribute.h > 0) {
+                                        imageW = attribute.w;
+                                        imageH = attribute.h;
+                                        break;
+                                    }
+                                }
+                            }
+                            if ((imageW == 0 || imageH == 0) && size != null && !(size instanceof TLRPC.TL_photoStrippedSize)) {
+                                imageW = size.w;
+                                imageH = size.h;
+                            }
+                        }
+                        if ((imageW == 0 || imageH == 0) && documentAttach != null) {
                             for (int a = 0, N = documentAttach.attributes.size(); a < N; a++) {
                                 TLRPC.DocumentAttribute attribute = documentAttach.attributes.get(a);
-                                if (attribute instanceof TLRPC.TL_documentAttributeVideo) {
+                                if (attribute instanceof TLRPC.TL_documentAttributeVideo
+                                        || attribute instanceof TLRPC.TL_documentAttributeImageSize) {
                                     imageW = attribute.w;
                                     imageH = attribute.h;
+                                    break;
                                 }
                             }
                         }
@@ -10140,13 +10214,21 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         }
                         photoImage.setRoundRadius(w / 2);
                         canChangeRadius = false;
-                    } else if (messageObject.needDrawBluredPreview() && !messageObject.hasExtendedMediaPreview()) {
+                    } else if (messageObject.needDrawBluredPreview() && !messageObject.hasExtendedMediaPreview() && !useWideChannelWidth) {
                         if (AndroidUtilities.isTablet()) {
                             w = (int) (AndroidUtilities.getMinTabletSide() * 0.6f);
                         } else {
                             w = (int) (Math.min(getParentWidth(), AndroidUtilities.displaySize.y) * 0.6f);
                         }
                         h = (int) (0.61f * w);
+                    }
+
+                    if (useWideChannelWidth && currentMessagesGroup == null) {
+                        int wideContentWidth = getWideChannelPostMediaContentWidth(messageObject, mediaBackground);
+                        if (w > 0 && h > 0 && wideContentWidth > 0 && w != wideContentWidth) {
+                            h = Math.min(photoHeight, Math.max(dp(1), Math.round(h * (wideContentWidth / (float) w))));
+                        }
+                        w = wideContentWidth;
                     }
 
                     int widthForCaption = 0;
@@ -10172,9 +10254,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                             w += firstLineWidth - currentLineWidth;
                         }
                         w -= dp(9);
-                        if (currentMessageObject != null && !currentMessageObject.isOutOwner() && isSideMenuPossibleLeftMargin()) {
+                        if (!messageObject.isWideChannelPost()
+                                && currentMessageObject != null
+                                && !currentMessageObject.isOutOwner()
+                                && isSideMenuPossibleLeftMargin()) {
                             w -= dp(ChatActivity.SIDE_MENU_WIDTH);
-                        } else if (isAvatarVisible) {
+                        } else if (!messageObject.isWideChannelPost() && isAvatarVisible) {
                             w -= dp(48);
                         }
                         if (currentPosition.siblingHeights != null) {
@@ -10241,7 +10326,13 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                                     } else {
                                         w -= dp(9);
                                     }
-                                    if (((isChat || m.isRepostPreview) && !isThreadPost && !m.isOutOwner() || m.forceAvatar || m.messageOwner.guestchat_via_from != null || m.getDialogId() == UserObject.VERIFY) && m.needDrawAvatar() && (rowPosition == null || rowPosition.edge)) {
+                                    if (!m.isWideChannelPost()
+                                            && ((isChat || m.isRepostPreview) && !isThreadPost && !m.isOutOwner()
+                                            || m.forceAvatar
+                                            || m.messageOwner.guestchat_via_from != null
+                                            || m.getDialogId() == UserObject.VERIFY)
+                                            && m.needDrawAvatar()
+                                            && (rowPosition == null || rowPosition.edge)) {
                                         w -= dp(48);
                                     }
                                     w += getAdditionalWidthForPosition(rowPosition);
@@ -10714,10 +10805,24 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                         width = getParentWidth() - dp(50 + (isSideMenued ? ChatActivity.SIDE_MENU_WIDTH : drawAvatar ? 52 : 0));
                     }
                 }
+                int wideCaptionBackgroundWidth = getWideChannelPostBackgroundWidth(messageObject, mediaBackground);
+                if (wideCaptionBackgroundWidth != 0) {
+                    backgroundWidth = wideCaptionBackgroundWidth;
+                    width = Math.min(width, wideCaptionBackgroundWidth);
+                }
                 if (drawSideButton != 0 && isRoundVideo) {
                     width -= dp(24);
                 }
                 int widthForCaption = width - dp(31 + (currentMessageObject.type != MessageObject.TYPE_ROUND_VIDEO ? 14 : 0)) - getExtraTextX() * 2;
+                if (wideCaptionBackgroundWidth != 0
+                        && captionLayout != null
+                        && captionFullWidth != widthForCaption) {
+                    captionLayout = null;
+                    prevCaptionLayout = null;
+                    captionFullWidth = 0;
+                    captionWidth = 0;
+                    captionHeight = 0;
+                }
                 if (!messageObject.isRestrictedMessage && captionLayout == null && (messageObject.caption != null || messageObject.isVoiceTranscriptionOpen())) {
                     currentCaption = messageObject.isVoiceTranscriptionOpen() ? messageObject.getVoiceTranscription() : messageObject.caption;
                     if (currentCaption != null && !TextUtils.isEmpty(messageObject.messageOwner.voiceTranscription) && currentMessageObject.isVoiceTranscriptionOpen() && !currentMessageObject.messageOwner.voiceTranscriptionFinal) {
@@ -10865,6 +10970,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
             }
 
+            if (shouldEnforceWideChannelPostOuterWidth(messageObject)) {
+                backgroundWidth = getWideChannelPostBackgroundWidth(messageObject, mediaBackground);
+            }
+
             for (BotButton botButton : botButtons) {
                 if (botButton.animatedEmojiDrawable != null) {
                     botButton.animatedEmojiDrawable.clear();
@@ -10916,7 +11025,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 substractBackgroundHeight = keyboardHeight = dp(44 + 4) * rows + dp(1) + separatorHeight * separators;
                 widthForButtons = backgroundWidth - dp(mediaBackground ? 0 : 9);
                 boolean fullWidth = false;
-                if (messageObject.wantedBotKeyboardWidth > widthForButtons) {
+                if (!messageObject.isWideChannelPost() && messageObject.wantedBotKeyboardWidth > widthForButtons) {
                     int maxButtonWidth = -dp(10 + (isSideMenued ? ChatActivity.SIDE_MENU_WIDTH : drawAvatar ? 52 : 0));
                     if (AndroidUtilities.isTablet()) {
                         maxButtonWidth += AndroidUtilities.getMinTabletSide();
@@ -11475,8 +11584,10 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         drawName = true;
         drawForwardedName = !isRepliesChat;
         drawPhotoImage = false;
-        int maxWidth = Math.min(dp(500), messageObject.getMaxMessageTextWidth());
-        backgroundWidth = maxWidth + dp(31);
+        int maxMessageWidth = messageObject.getMaxMessageTextWidth();
+        int wideBackgroundWidth = getWideChannelPostBackgroundWidth(messageObject);
+        int maxWidth = wideBackgroundWidth != 0 ? wideBackgroundWidth - dp(31) : Math.min(dp(500), maxMessageWidth);
+        backgroundWidth = wideBackgroundWidth != 0 ? wideBackgroundWidth : maxWidth + dp(31);
 
         TLRPC.MessageMedia m = MessageObject.getMedia(messageObject.messageOwner);
         TLRPC.TL_textWithEntities title;
@@ -13882,9 +13993,13 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         setMessageObject(messageObject, currentMessagesGroup, pinnedBottom, pinnedTop, firstInChat);
     }
 
-    private int getGroupPhotosWidth() {
+    private int getGroupPhotosBaseWidth() {
+        return getGroupPhotosBaseWidth(currentMessageObject);
+    }
+
+    private int getGroupPhotosBaseWidth(MessageObject messageObject) {
         int width = getParentWidth();
-        if (currentMessageObject != null && currentMessageObject.preview) {
+        if (messageObject != null && messageObject.preview) {
             width = parentWidth;
         }
         if (!AndroidUtilities.isInMultiwindow && AndroidUtilities.isTablet() && (!AndroidUtilities.isSmallTablet() || getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE)) {
@@ -13893,6 +14008,77 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         } else {
             return width;
         }
+    }
+
+    private int getGroupPhotosWidth() {
+        int width = getGroupPhotosBaseWidth();
+        if (currentMessageObject != null && currentMessageObject.isWideChannelPost()) {
+            return WideChannelPostLayout.groupedMediaViewportWidth(width,
+                    getWideChannelPostLeadingInset(currentMessageObject));
+        }
+        return width;
+    }
+
+    private int getWideChannelPostBackgroundWidth(MessageObject messageObject) {
+        return getWideChannelPostBackgroundWidth(messageObject, false);
+    }
+
+    private int getWideChannelPostBackgroundWidth(MessageObject messageObject, boolean mediaBackground) {
+        if (messageObject == null || !messageObject.isWideChannelPost()) {
+            return 0;
+        }
+        int width = getGroupPhotosBaseWidth();
+        if (width <= 0) {
+            return 0;
+        }
+        return WideChannelPostLayout.backgroundWidth(width,
+                getWideChannelPostLeadingInset(messageObject), mediaBackground);
+    }
+
+    private int applyWideChannelPostWidth(MessageObject messageObject, int regularWidth) {
+        int wideWidth = getWideChannelPostBackgroundWidth(messageObject);
+        return wideWidth == 0 ? regularWidth : wideWidth;
+    }
+
+    int getWideChannelPostMediaWidth(MessageObject messageObject) {
+        if (messageObject == null || !messageObject.isWideChannelPost()) {
+            return 0;
+        }
+        int width = getGroupPhotosBaseWidth();
+        if (width <= 0) {
+            return 0;
+        }
+        return WideChannelPostLayout.mediaContentWidth(width,
+                getWideChannelPostLeadingInset(messageObject));
+    }
+
+    private int getWideChannelPostLeadingInset(MessageObject messageObject) {
+        if (isSideMenued || isSideMenuEnabled) {
+            return dp(ChatActivity.SIDE_MENU_WIDTH);
+        }
+        boolean drawsAvatar = messageObject != null
+                && !messageObject.isOutOwner()
+                && (isChat
+                    || messageObject.forceAvatar
+                    || messageObject.messageOwner.guestchat_via_from != null
+                    || messageObject.getDialogId() == UserObject.VERIFY)
+                && isAvatarVisible;
+        return drawsAvatar ? dp(48) : 0;
+    }
+
+    private int getWideChannelPostMediaContentWidth(MessageObject messageObject, boolean mediaBackground) {
+        int background = getWideChannelPostBackgroundWidth(messageObject, mediaBackground);
+        return background == 0 ? 0 : WideChannelPostLayout.mediaContentWidth(background, mediaBackground);
+    }
+
+    private boolean shouldEnforceWideChannelPostOuterWidth(MessageObject messageObject) {
+        return messageObject != null
+                && messageObject.isWideChannelPost()
+                && (currentMessagesGroup == null || currentMessagesGroup.isDocuments)
+                && !messageObject.isAnyKindOfSticker()
+                && !messageObject.isAnimatedEmoji()
+                && !messageObject.isDice()
+                && !messageObject.isRoundVideo();
     }
 
     public boolean isUpdating() {
@@ -17133,7 +17319,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
                 float collapsed = 1f;
                 int blockSpoilersColor = spoilersColor;
-                final int width = (int) (block.maxRight + dp(24) > maxWidth * .7f ? maxWidth : block.maxRight + dp(24));
+                final int width = currentMessageObject != null && currentMessageObject.isWideChannelPost() && block.quote
+                        ? (int) maxWidth
+                        : (int) (block.maxRight + dp(24) > maxWidth * .7f ? maxWidth : block.maxRight + dp(24));
                 if (block.quote) {
                     if (quoteLine == null) {
                         quoteLine = new ReplyMessageLine(this);
@@ -18926,6 +19114,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     }
 
     protected boolean checkNeedDrawShareButton(MessageObject messageObject) {
+        if (messageObject.isWideChannelPost()) return false;
         if (!messageObject.isSaved && NaConfig.INSTANCE.getHideShareButtonInChannel().Bool()) return false;
         if (currentMessageObject.isAyuDeleted()) return false;
         if (isReportChat) return false;
@@ -21872,7 +22061,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 textColorKey = Theme.key_windowBackgroundWhiteBlackText;
             }
             float collapsed = 1f;
-            final int width = (int) (block.maxRight + dp(24) > maxWidth * .7f ? maxWidth : block.maxRight + dp(24));
+            final int width = currentMessageObject != null && currentMessageObject.isWideChannelPost() && block.quote
+                    ? (int) maxWidth
+                    : (int) (block.maxRight + dp(24) > maxWidth * .7f ? maxWidth : block.maxRight + dp(24));
             if (block.quoteCollapse) {
                 AndroidUtilities.rectTmp.set(0, -block.padTop + dp(block.first ? 3 + 1.66f : 3), width, block.height(transitionParams) + dp(4));
                 AndroidUtilities.rectTmp.offset((block.isRtl() ? rtlOffset - dp(10) : 0), 0);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/GroupMedia.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/GroupMedia.java
@@ -91,17 +91,20 @@ public class GroupMedia {
         }
         layout.medias.clear();
         layout.medias.addAll(paidMedia.extended_media);
-        layout.calculate();
+        layout.calculate(messageObject.isWideChannelPost());
 
         if (overrideWidth > 0) {
             maxWidth = overrideWidth;
         } else {
-            if (AndroidUtilities.isTablet()) {
+            int wideChannelWidth = cell.getWideChannelPostMediaWidth(messageObject);
+            if (wideChannelWidth != 0) {
+                maxWidth = wideChannelWidth;
+            } else if (AndroidUtilities.isTablet()) {
                 maxWidth = AndroidUtilities.getMinTabletSide() - AndroidUtilities.dp(122);
             } else {
                 maxWidth = Math.min(cell.getParentWidth(), AndroidUtilities.displaySize.y) - AndroidUtilities.dp(64 + (cell.checkNeedDrawShareButton(messageObject) ? 10 : 0));
             }
-            if (cell.needDrawAvatar()) {
+            if (wideChannelWidth == 0 && cell.needDrawAvatar()) {
                 maxWidth -= dp(52);
             }
         }
@@ -208,12 +211,15 @@ public class GroupMedia {
             f = 1000f / layout.width;
             maxWidth = overrideWidth;
         } else {
-            if (AndroidUtilities.isTablet()) {
+            int wideChannelWidth = cell.getWideChannelPostMediaWidth(messageObject);
+            if (wideChannelWidth != 0) {
+                maxWidth = wideChannelWidth;
+            } else if (AndroidUtilities.isTablet()) {
                 maxWidth = AndroidUtilities.getMinTabletSide() - AndroidUtilities.dp(122);
             } else {
                 maxWidth = Math.min(cell.getParentWidth(), AndroidUtilities.displaySize.y) - AndroidUtilities.dp(64 + (cell.checkNeedDrawShareButton(messageObject) ? 10 : 0));
             }
-            if (cell.needDrawAvatar()) {
+            if (wideChannelWidth == 0 && cell.needDrawAvatar()) {
                 maxWidth -= dp(52);
             }
         }
@@ -895,6 +901,7 @@ public class GroupMedia {
 
         public int maxSizeWidth = 800;
         public float maxSizeHeight = 814;
+        private boolean wideChannelPost;
 
         public final GroupedMessages.TransitionParams transitionParams = new GroupedMessages.TransitionParams();
 
@@ -927,7 +934,8 @@ public class GroupMedia {
             return maxSizeWidth / sum;
         }
 
-        public void calculate() {
+        public void calculate(boolean wideChannelPost) {
+            this.wideChannelPost = wideChannelPost;
             posArray.clear();
             positions.clear();
 
@@ -939,8 +947,8 @@ public class GroupMedia {
                 maxY = 0;
                 return;
             }
-            maxSizeWidth = 800;
-            int firstSpanAdditionalSize = 200;
+            maxSizeWidth = wideChannelPost ? 1000 : 800;
+            int firstSpanAdditionalSize = 1000 - maxSizeWidth;
 
             StringBuilder proportions = new StringBuilder();
             float averageAspectRatio = 1.0f;
@@ -970,8 +978,23 @@ public class GroupMedia {
                     } else {
                         photoSize = null;
                     }
-                    position.photoWidth = photoSize == null ? 100 : photoSize.w;
-                    position.photoHeight = photoSize == null ? 100 : photoSize.h;
+                    if (photoSize != null && photoSize.w > 0 && photoSize.h > 0) {
+                        position.photoWidth = photoSize.w;
+                        position.photoHeight = photoSize.h;
+                    } else if (m.media instanceof TLRPC.TL_messageMediaDocument
+                            && ((TLRPC.TL_messageMediaDocument) m.media).document != null) {
+                        TLRPC.Document document = ((TLRPC.TL_messageMediaDocument) m.media).document;
+                        for (int i = 0; i < document.attributes.size(); i++) {
+                            TLRPC.DocumentAttribute attribute = document.attributes.get(i);
+                            if ((attribute instanceof TLRPC.TL_documentAttributeVideo
+                                    || attribute instanceof TLRPC.TL_documentAttributeImageSize)
+                                    && attribute.w > 0 && attribute.h > 0) {
+                                position.photoWidth = attribute.w;
+                                position.photoHeight = attribute.h;
+                                break;
+                            }
+                        }
+                    }
                 } else {
                     position.photoWidth = 100;
                     position.photoHeight = 100;
@@ -1019,7 +1042,10 @@ public class GroupMedia {
             if (count == 1) {
                 GroupedMessagePosition position1 = posArray.get(0);
                 float w, h;
-                if (position1.aspectRatio >= 1) {
+                if (wideChannelPost) {
+                    w = maxSizeWidth;
+                    h = Math.min(maxSizeHeight, w / position1.aspectRatio);
+                } else if (position1.aspectRatio >= 1) {
                     w = maxSizeWidth;
                     h = w / position1.aspectRatio / maxSizeWidth * maxSizeHeight;
                 } else {
@@ -1293,7 +1319,7 @@ public class GroupMedia {
                     }
                 }
                 TLRPC.MessageExtendedMedia media = medias.get(a);
-                if (!isOut && true /* media.needDrawAvatarInternal()*/) {
+                if (!wideChannelPost && !isOut) {
                     if (pos.edge) {
                         if (pos.spanSize != 1000) {
                             pos.spanSize += avatarOffset;
@@ -1414,7 +1440,7 @@ public class GroupMedia {
 
         public TLRPC.MessageExtendedMedia findMediaWithFlags(int flags) {
             if (!medias.isEmpty() && positions.isEmpty()) {
-                calculate();
+                calculate(wideChannelPost);
             }
             for (int i = 0; i < medias.size(); i++) {
                 TLRPC.MessageExtendedMedia media = medias.get(i);

--- a/TMessagesProj/src/main/kotlin/app/exteraless/chats/ChatsConfig.kt
+++ b/TMessagesProj/src/main/kotlin/app/exteraless/chats/ChatsConfig.kt
@@ -148,6 +148,9 @@ object ChatsConfig {
 
     // ---- Сообщения ----
 
+    @JvmField
+    val wideChannelPosts = addConfig("OEChatsWideChannelPosts", ConfigItem.configTypeBool, false)
+
     /** Убрать «хвостик» пузыря (только UI). */
     @JvmField
     val removeMessageTail = addConfig("OEChatsRemoveMessageTail", ConfigItem.configTypeBool, true)
@@ -238,6 +241,12 @@ object ChatsConfig {
     fun stickerShape(): Int {
         ensureLoaded()
         return stickerShape.Int()
+    }
+
+    @JvmStatic
+    fun wideChannelPosts(): Boolean {
+        ensureLoaded()
+        return wideChannelPosts.Bool()
     }
 
     @JvmStatic

--- a/TMessagesProj/src/main/res/values-es/strings_oe_chats.xml
+++ b/TMessagesProj/src/main/res/values-es/strings_oe_chats.xml
@@ -79,6 +79,11 @@
     <string name="OEChatsChatSettingsInfo">Ajustes multimedia, icono de la app y más</string>
     <string name="OEStickerSizeSmall">Pequeño</string>
     <string name="OEStickerSizeLarge">Grande</string>
+    <string name="OEChatsChannelPosts">Publicaciones de canales</string>
+    <string name="OEChatsWideChannelPosts">Publicaciones anchas</string>
+    <string name="OEChatsWideChannelPostsPreviewText">Noticias, fotos y vídeos</string>
+    <string name="OEChatsWideChannelPostsPreviewReply">Publicación reenviada</string>
+    <string name="OEChatsWideChannelPostsFooter">Las publicaciones y reenvíos usan el ancho disponible.</string>
     <string name="OEDetailsDate">Fecha</string>
     <string name="OEDetailsForwardedDate">Fecha de reenvío</string>
     <string name="OEDetailsEditedDate">Fecha de edición</string>

--- a/TMessagesProj/src/main/res/values-pl-rPL/strings_oe_chats.xml
+++ b/TMessagesProj/src/main/res/values-pl-rPL/strings_oe_chats.xml
@@ -79,6 +79,11 @@
     <string name="OEChatsChatSettingsInfo">Ustawienia mediów, ikona aplikacji i inne</string>
     <string name="OEStickerSizeSmall">Małe</string>
     <string name="OEStickerSizeLarge">Duże</string>
+    <string name="OEChatsChannelPosts">Posty na kanałach</string>
+    <string name="OEChatsWideChannelPosts">Szerokie posty</string>
+    <string name="OEChatsWideChannelPostsPreviewText">Wiadomości, zdjęcia i filmy</string>
+    <string name="OEChatsWideChannelPostsPreviewReply">Przekazany post z kanału</string>
+    <string name="OEChatsWideChannelPostsFooter">Posty i przekazania używają dostępnej szerokości.</string>
     <string name="OEDetailsDate">Data</string>
     <string name="OEDetailsForwardedDate">Data przesłania dalej</string>
     <string name="OEDetailsEditedDate">Data edycji</string>

--- a/TMessagesProj/src/main/res/values-ru-rRU/strings_oe_chats.xml
+++ b/TMessagesProj/src/main/res/values-ru-rRU/strings_oe_chats.xml
@@ -82,6 +82,11 @@
     <string name="OEChatsChatSettingsInfo">Настройки медиа, значок приложения и другое</string>
     <string name="OEStickerSizeSmall">Маленький</string>
     <string name="OEStickerSizeLarge">Большой</string>
+    <string name="OEChatsChannelPosts">Посты в каналах</string>
+    <string name="OEChatsWideChannelPosts">Широкие посты</string>
+    <string name="OEChatsWideChannelPostsPreviewText">Новости, фото и видео</string>
+    <string name="OEChatsWideChannelPostsPreviewReply">Пересланный пост канала</string>
+    <string name="OEChatsWideChannelPostsFooter">Посты и пересылки в каналах займут доступную ширину.</string>
     <string name="OEChatsUnmuteWithVolumeButtonsInfo">Кнопки громкости включат звук у беззвучного видео вместо изменения громкости.</string>
     <string name="OEChatsShowResultsBeforeVotingInfo">Результаты публичных опросов видны, не отдавая голос.</string>
     <string name="OEChatsRememberLastUsedCameraInfo">Следующее видеосообщение начнётся с той камеры, которой вы снимали в прошлый раз.</string>

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_oe_chats.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_oe_chats.xml
@@ -79,6 +79,11 @@
     <string name="OEChatsChatSettingsInfo">媒体设置、应用图标等</string>
     <string name="OEStickerSizeSmall">小</string>
     <string name="OEStickerSizeLarge">大</string>
+    <string name="OEChatsChannelPosts">频道帖子</string>
+    <string name="OEChatsWideChannelPosts">宽帖子</string>
+    <string name="OEChatsWideChannelPostsPreviewText">新闻、照片和视频</string>
+    <string name="OEChatsWideChannelPostsPreviewReply">转发的频道帖子</string>
+    <string name="OEChatsWideChannelPostsFooter">频道帖子和转发内容将使用可用宽度。</string>
     <string name="OEDetailsDate">日期</string>
     <string name="OEDetailsForwardedDate">转发日期</string>
     <string name="OEDetailsEditedDate">编辑日期</string>

--- a/TMessagesProj/src/main/res/values/strings_oe_chats.xml
+++ b/TMessagesProj/src/main/res/values/strings_oe_chats.xml
@@ -88,6 +88,11 @@
     <string name="OEChatsChatSettingsInfo">Media Settings, App Icon and other</string>
     <string name="OEStickerSizeSmall">Small</string>
     <string name="OEStickerSizeLarge">Large</string>
+    <string name="OEChatsChannelPosts">Channel posts</string>
+    <string name="OEChatsWideChannelPosts">Wide posts</string>
+    <string name="OEChatsWideChannelPostsPreviewText">News, photos and videos</string>
+    <string name="OEChatsWideChannelPostsPreviewReply">Forwarded channel post</string>
+    <string name="OEChatsWideChannelPostsFooter">Channel posts and forwards use the available width.</string>
 
     <string name="OEDetailsDate">Date</string>
     <string name="OEDetailsForwardedDate">Forward Date</string>


### PR DESCRIPTION
Добавлена настройка "Широкие посты":
- Канальные посты и пересылки используют доступную ширину экрана.
- Учтены текстовые сообщения, документы, медиа, альбомы фото и видео, платные медиа, ответы, цитаты и состояния загрузки и тд
- Группы медиа пересчитываются под фактическую ширину окна, включая поворот и split-screen.


### English
Adds a “Wide posts” setting:
- Channel posts and forwards use the available screen width.
- Covers text posts, documents, media, photo and video albums, paid media, replies, quotes, and loading states.

## Preview 

https://github.com/user-attachments/assets/36dfc652-f2ad-4a43-bed8-263da122734f


https://github.com/user-attachments/assets/2bf57b0b-86c1-4e50-ad39-dc48651d28dd

