### PR TITLE
Переключать Голос И Кружок По Тапу Из Коробки !!!

### DIFF
--- a/TMessagesProj/src/main/java/app/exteraless/config/LegacyDefaults.java
+++ b/TMessagesProj/src/main/java/app/exteraless/config/LegacyDefaults.java
@@ -18,6 +18,7 @@ public abstract class LegacyDefaults {
             "showMessageDetails",
             "showTranslate",
             "showRepeat",
+            "UseChatAttachEnterMenu",
     };
 
     private static final String[] INT_KEYS = {

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/NekoConfig.java
@@ -156,7 +156,7 @@ public class NekoConfig {
     public static ConfigItem disableProximityEvents = addConfig("DisableProximityEvents", configTypeBool, false);
 
     public static ConfigItem ignoreContentRestrictions = addConfig("ignoreContentRestrictions", configTypeBool, true);
-    public static ConfigItem useChatAttachMediaMenu = addConfig("UseChatAttachEnterMenu", configTypeBool, true);
+    public static ConfigItem useChatAttachMediaMenu = addConfig("UseChatAttachEnterMenu", configTypeBool, false);
     public static ConfigItem disableLinkPreviewByDefault = addConfig("DisableLinkPreviewByDefault", configTypeBool, false);
     public static ConfigItem sendCommentAfterForward = addConfig("SendCommentAfterForward", configTypeBool, true);
     public static ConfigItem disableTrending = addConfig("DisableTrending", configTypeBool, true);


### PR DESCRIPTION
## Что Не Так Сейчас !!!

Кнопка Записи По Умолчанию Живёт В Режиме Меню — Того Самого Троеточия !!! Тап По Ней Открывает Попап Вместо Того , Чтобы Просто Переключить Голосовое Сообщение На Кружок !!! Лишний Шаг На Ровном Месте , А В Стоковом Телеграме Это Один Тап !!!

## Что Сделано !!!

`UseChatAttachEnterMenu` Теперь По Умолчанию `false` , То Есть Поведение Совпадает Со Стоком : Тап Переключает Голос И Кружок , Удержание Пишет !!!

Ключ Добавлен В `LegacyDefaults` , Поэтому У Тех , Кто Уже Сидит На Клиенте , Ничего Не Поменяется — Старый Дефолт Останется При Них !!!

## Как Вернуть Троеточие !!!

Настройки → Чаты → `Tap to Switch Voice and Video` — Выключить , И Меню Вернётся !!!
