### PR TITLE
Keep the chosen monet palette after process restarts

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
@@ -291,6 +291,13 @@ public class ApplicationLoader extends Application implements CameraXConfig.Prov
         app.exteraless.chats.ChatsConfig.init();
         app.exteraless.general.GeneralConfig.init();
         app.exteraless.utils.UtilsConfig.init();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // Суффикс набора Monet запекается в ThemeInfo.assetName при первой загрузке
+            // класса Theme. Если она случилась до загрузки конфигов (процесс поднялся
+            // ради ресивера/провайдера), палитра молча откатывалась бы на набор по
+            // умолчанию — патчим assetName после инициализации конфигов.
+            org.telegram.ui.ActionBar.Theme.reloadMonetThemes();
+        }
         app.exteraless.plugins.PluginsController.getInstance().init(applicationContext);
         SharedPrefsHelper.init(applicationContext);
         FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(AndroidUtil.shouldEnableCrashlytics());


### PR DESCRIPTION
выбранная палитра monet (classic) слетала на telemone после холодного старта: assetName для монет-тем вычислялся в static-блоке Theme, а он может загрузиться раньше чем конфиги прочитаются. в настройках при этом оставался classic, а красилась telemone.

теперь после загрузки конфигов один раз дёргается reloadMonetThemes и assetName встаёт правильный независимо от порядка загрузки классов.