### PR TITLE
Fix huge gaps around the link card in Chats settings

### DIFF
--- a/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraChatsActivity.java
+++ b/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraChatsActivity.java
@@ -1815,6 +1815,7 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
 
         private void bindInfo(TextInfoPrivacyCell cell, int position) {
             boolean bottom = position == videosDividerRow;
+            cell.setFixedSize(0);
             if (position == doubleTapDividerRow) {
                 cell.setText(getString(R.string.OEChatsDoubleTapInfo));
             } else if (position == chatsDividerRow) {
@@ -1833,6 +1834,9 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
                 cell.setText(getString(R.string.OEChatsPauseOnMinimizeInfo));
             } else {
                 cell.setText(null);
+                // Без текста у TextInfoPrivacyCell остаются футерные отступы 10+17dp
+                // и пустая строка — между карточками зияет дыра. Фиксируем высоту.
+                cell.setFixedSize(12);
             }
             cell.setBackground(Theme.getThemedDrawable(mContext,
                     bottom ? R.drawable.greydivider_bottom : R.drawable.greydivider,


### PR DESCRIPTION
The empty section dividers around the AI Chat / Chat Settings card kept the default footer padding (10+17dp) plus an empty text line, so the card floated in a ~60dp void above and below.

Now empty dividers get a fixed 12dp height instead. Text footers untouched.