### PR TITLE
Add missing section headers in Chats and Appearance settings

### DIFF
--- a/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraAppearanceActivity.java
+++ b/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraAppearanceActivity.java
@@ -133,6 +133,7 @@ public class OpenExteraAppearanceActivity extends BaseNekoSettingsActivity {
     private int foldersDividerRow;
 
     // Links
+    private int linksHeaderRow;
     private int appNavigationRow;
     private int iconPacksRow;
     private int pillStackRow;
@@ -187,6 +188,7 @@ public class OpenExteraAppearanceActivity extends BaseNekoSettingsActivity {
 
         // Порядок как в 12.9.0: строки-переходы идут сразу после «Chat Folders»,
         // до секции общего вида.
+        linksHeaderRow = addRow("linksHeader");
         appNavigationRow = addRow("appNavigation");
         iconPacksRow = addRow("iconPacks");
         pillStackRow = addRow("pillStack");
@@ -803,6 +805,8 @@ public class OpenExteraAppearanceActivity extends BaseNekoSettingsActivity {
                         cell.setText(getString(R.string.OEAppearanceChatList));
                     } else if (position == foldersHeaderRow) {
                         cell.setText(getString(R.string.OEAppearanceFolders));
+                    } else if (position == linksHeaderRow) {
+                        cell.setText(getString(R.string.OEAppearanceInterface));
                     }
                     break;
                 }
@@ -1010,7 +1014,7 @@ public class OpenExteraAppearanceActivity extends BaseNekoSettingsActivity {
                 return TYPE_SECTION_SLIDER;
             } else if (position == appearanceHeaderRow || position == sectionsHeaderRow
                     || position == blurHeaderRow || position == chatListHeaderRow
-                    || position == foldersHeaderRow) {
+                    || position == foldersHeaderRow || position == linksHeaderRow) {
                 return TYPE_HEADER;
             } else if (position == appearanceDividerRow || position == sectionsDividerRow
                     || position == blurDividerRow || position == avatarsDividerRow

--- a/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraChatsActivity.java
+++ b/TMessagesProj/src/main/java/app/exteraless/settings/OpenExteraChatsActivity.java
@@ -112,6 +112,7 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
     private int stickerShapeDividerRow;
 
     // Links
+    private int linksHeaderRow;
     private int aiChatRow;
     private int chatSettingsRow;
     private int linksDividerRow;
@@ -260,6 +261,7 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
         stickerShapeRow = addRow("stickerShape");
         stickerShapeDividerRow = addRow();
 
+        linksHeaderRow = addRow("linksHeader");
         aiChatRow = addRow("aiChat");
         chatSettingsRow = addRow("chatSettings");
         linksDividerRow = addRow();
@@ -1521,6 +1523,8 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
         private void bindHeader(HeaderCell cell, int position) {
             if (position == stickerShapeHeaderRow) {
                 cell.setText(getString(R.string.OEChatsStickerShape));
+            } else if (position == linksHeaderRow) {
+                cell.setText(getString(R.string.Other));
             } else if (position == stickersHeaderRow) {
                 cell.setText(getString(R.string.OEChatsStickersAndEmoji));
             } else if (position == doubleTapHeaderRow) {
@@ -1857,6 +1861,7 @@ public class OpenExteraChatsActivity extends BaseNekoSettingsActivity {
 
         private boolean isHeader(int position) {
             return position == stickerShapeHeaderRow
+                    || position == linksHeaderRow
                     || position == stickersHeaderRow || position == doubleTapHeaderRow
                     || position == chatsHeaderRow || position == messagesHeaderRow
                     || position == channelPostsHeaderRow

--- a/TMessagesProj/src/main/res/values-ru-rRU/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values-ru-rRU/strings_oe_appearance.xml
@@ -18,6 +18,7 @@
     <string name="OEAppearanceChatListInfo">Снежинки будут падать в шапке, боковом меню и на фоне чатов.</string>
 
     <string name="OEAppearanceFolders">Папки</string>
+    <string name="OEAppearanceInterface">Интерфейс</string>
     <string name="OEAppearanceTabTitleStyle">Заголовок папки</string>
     <string name="OEAppearanceTabTitleStyleTextOnly">Только названия</string>
     <string name="OEAppearanceTabTitleStyleIconsOnly">Только иконки</string>

--- a/TMessagesProj/src/main/res/values/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values/strings_oe_appearance.xml
@@ -29,6 +29,7 @@
 
     <!-- Folders (Tabs) -->
     <string name="OEAppearanceFolders">Folders</string>
+    <string name="OEAppearanceInterface">Interface</string>
     <string name="OEAppearanceTabTitleStyle">Folder Title</string>
     <string name="OEAppearanceTabTitleStyleTextOnly">Names only</string>
     <string name="OEAppearanceTabTitleStyleIconsOnly">Icons only</string>


### PR DESCRIPTION
The link cards were the only groups without a section header:

- Chats: AI Chat / Chat Settings -> header "Other"
- Appearance: App Navigation / Icon Packs / Pill Stack -> header "Interface"