### PR TITLE
Switch loaders to M3 Expressive behind the MD3 loader setting

### DIFF
--- a/TMessagesProj/src/main/java/app/exteraless/appearance/M3CircularProgress.java
+++ b/TMessagesProj/src/main/java/app/exteraless/appearance/M3CircularProgress.java
@@ -28,12 +28,11 @@ public class M3CircularProgress {
     public static final int STYLE_WAVY = 3;
 
     /**
-     * Понижение стиля при выключённой настройке:
+     * Понижение стиля при выключённой настройке «MD3 Loaders»:
      * {@code if (!getNewLoadingStyle() && i != 0 && i != 1) i = 0;}
-     * Monet-тема включает M3-лоадеры независимо от тумблера.
      */
     public static int degradeStyle(int style) {
-        if (!AppearanceConfig.newLoadingStyle() && !org.telegram.ui.ActionBar.Theme.isCurrentThemeMonet()
+        if (!AppearanceConfig.newLoadingStyle()
                 && style != STYLE_LEGACY && style != STYLE_LOADING_INDICATOR) {
             return STYLE_LEGACY;
         }

--- a/TMessagesProj/src/main/java/app/exteraless/appearance/M3CircularProgress.java
+++ b/TMessagesProj/src/main/java/app/exteraless/appearance/M3CircularProgress.java
@@ -30,9 +30,11 @@ public class M3CircularProgress {
     /**
      * Понижение стиля при выключённой настройке:
      * {@code if (!getNewLoadingStyle() && i != 0 && i != 1) i = 0;}
+     * Monet-тема включает M3-лоадеры независимо от тумблера.
      */
     public static int degradeStyle(int style) {
-        if (!AppearanceConfig.newLoadingStyle() && style != STYLE_LEGACY && style != STYLE_LOADING_INDICATOR) {
+        if (!AppearanceConfig.newLoadingStyle() && !org.telegram.ui.ActionBar.Theme.isCurrentThemeMonet()
+                && style != STYLE_LEGACY && style != STYLE_LOADING_INDICATOR) {
             return STYLE_LEGACY;
         }
         return style;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/LineProgressView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/LineProgressView.java
@@ -21,6 +21,7 @@ import android.view.animation.DecelerateInterpolator;
 import app.exteraless.appearance.AppearanceConfig;
 
 import org.telegram.messenger.AndroidUtilities;
+import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.voip.CellFlickerDrawable;
 
 public class LineProgressView extends View {
@@ -125,7 +126,7 @@ public class LineProgressView extends View {
      * При выключенном newLoadingStyle тип принудительно 0, как в exteraGram.
      */
     public void setProgressType(int type) {
-        if (!AppearanceConfig.newLoadingStyle()) {
+        if (!AppearanceConfig.newLoadingStyle() && !Theme.isCurrentThemeMonet()) {
             this.type = 0;
             return;
         }
@@ -137,8 +138,8 @@ public class LineProgressView extends View {
     }
 
     public void onDraw(Canvas canvas) {
-        // При новом стиле рисует BaseProgressIndicator
-        if (AppearanceConfig.newLoadingStyle()) {
+        // При новом стиле или Monet-теме рисует BaseProgressIndicator
+        if (AppearanceConfig.newLoadingStyle() || Theme.isCurrentThemeMonet()) {
             drawMaterial3(canvas);
             updateAnimation();
             return;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/LineProgressView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/LineProgressView.java
@@ -21,7 +21,6 @@ import android.view.animation.DecelerateInterpolator;
 import app.exteraless.appearance.AppearanceConfig;
 
 import org.telegram.messenger.AndroidUtilities;
-import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.Components.voip.CellFlickerDrawable;
 
 public class LineProgressView extends View {
@@ -126,7 +125,7 @@ public class LineProgressView extends View {
      * При выключенном newLoadingStyle тип принудительно 0, как в exteraGram.
      */
     public void setProgressType(int type) {
-        if (!AppearanceConfig.newLoadingStyle() && !Theme.isCurrentThemeMonet()) {
+        if (!AppearanceConfig.newLoadingStyle()) {
             this.type = 0;
             return;
         }
@@ -138,8 +137,8 @@ public class LineProgressView extends View {
     }
 
     public void onDraw(Canvas canvas) {
-        // При новом стиле или Monet-теме рисует BaseProgressIndicator
-        if (AppearanceConfig.newLoadingStyle() || Theme.isCurrentThemeMonet()) {
+        // При новом стиле рисует BaseProgressIndicator
+        if (AppearanceConfig.newLoadingStyle()) {
             drawMaterial3(canvas);
             updateAnimation();
             return;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/RadialProgressView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/RadialProgressView.java
@@ -63,7 +63,12 @@ public class RadialProgressView extends View implements Drawable.Callback {
     // дуга с дорожкой и зазором (стили 2 и 3) считается вручную в M3CircularProgress.
     private int currentStyle = M3CircularProgress.STYLE_LEGACY;
     private int trackColor;
+    private boolean trackColorCustom;
     private M3CircularProgress m3;
+    // Автовыбор стиля по теме: на Monet спиннеры — LoadingIndicator (морф-фигура),
+    // детерминированный прогресс — CircularProgressIndicator (дуга с дорожкой).
+    private int themeStyle = -1;
+    private boolean manualStyle;
 
     public RadialProgressView(Context context) {
         this(context, null);
@@ -233,6 +238,12 @@ public class RadialProgressView extends View implements Drawable.Callback {
         if (m3IndicatorView != null) {
             m3IndicatorView.setIndicatorColor(color);
         }
+        if (!trackColorCustom) {
+            trackColor = Theme.multAlpha(progressColor, 0.2f);
+            if (m3 != null) {
+                m3.setTrackColor(trackColor);
+            }
+        }
     }
 
     /**
@@ -240,6 +251,11 @@ public class RadialProgressView extends View implements Drawable.Callback {
      * 2 — CircularProgressIndicator, 3 — он же с волной.
      */
     public void setStyle(int style) {
+        manualStyle = true;
+        setStyleInternal(style);
+    }
+
+    private void setStyleInternal(int style) {
         style = M3CircularProgress.degradeStyle(style);
         if (currentStyle == style
                 && (style != M3CircularProgress.STYLE_LOADING_INDICATOR || m3Drawable != null)) {
@@ -271,6 +287,9 @@ public class RadialProgressView extends View implements Drawable.Callback {
             }
             // IndicatorTrackGapSize = dp(2)
             m3.setGap(AndroidUtilities.dp(2));
+            if (!trackColorCustom) {
+                trackColor = Theme.multAlpha(progressColor, 0.2f);
+            }
             m3.setTrackColor(trackColor);
             setWavy(currentStyle == M3CircularProgress.STYLE_WAVY);
         }
@@ -283,9 +302,27 @@ public class RadialProgressView extends View implements Drawable.Callback {
 
     public void setTrackColor(int color) {
         trackColor = color;
+        trackColorCustom = true;
         if (m3 != null) {
             m3.setTrackColor(color);
         }
+    }
+
+    private void applyThemeStyle() {
+        if (manualStyle) {
+            return;
+        }
+        int desired = Theme.isCurrentThemeMonet()
+                ? (noProgress ? M3CircularProgress.STYLE_LOADING_INDICATOR : M3CircularProgress.STYLE_CIRCULAR)
+                : M3CircularProgress.STYLE_LEGACY;
+        if (desired == themeStyle) {
+            return;
+        }
+        themeStyle = desired;
+        if (!trackColorCustom) {
+            trackColor = Theme.multAlpha(progressColor, 0.2f);
+        }
+        setStyleInternal(desired);
     }
 
     /** SetWavyValues(dp(15), dp(1.6f), dp(5), 0.05f). */
@@ -332,6 +369,7 @@ public class RadialProgressView extends View implements Drawable.Callback {
     }
 
     private void drawArc(Canvas canvas) {
+        applyThemeStyle();
         drawingCircleLenght = currentCircleLength;
         if (currentStyle == M3CircularProgress.STYLE_LOADING_INDICATOR && m3Drawable != null) {
             m3Drawable.setBounds((int) cicleRect.left, (int) cicleRect.top,

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/RadialProgressView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/RadialProgressView.java
@@ -22,6 +22,7 @@ import androidx.annotation.NonNull;
 
 import com.google.android.material.loadingindicator.LoadingIndicator;
 
+import app.exteraless.appearance.AppearanceConfig;
 import app.exteraless.appearance.M3CircularProgress;
 
 import org.telegram.messenger.AndroidUtilities;
@@ -65,9 +66,9 @@ public class RadialProgressView extends View implements Drawable.Callback {
     private int trackColor;
     private boolean trackColorCustom;
     private M3CircularProgress m3;
-    // Автовыбор стиля по теме: на Monet спиннеры — LoadingIndicator (морф-фигура),
-    // детерминированный прогресс — волнистая дуга с дорожкой (CircularProgressIndicator + волна).
-    private int themeStyle = -1;
+    // Автовыбор стиля по настройке «MD3 Loaders»: при включённой спиннеры — LoadingIndicator
+    // (морф-фигура), детерминированный прогресс — волнистая дуга с дорожкой (CircularProgressIndicator + волна).
+    private int configuredStyle = -1;
     private boolean manualStyle;
 
     public RadialProgressView(Context context) {
@@ -308,17 +309,17 @@ public class RadialProgressView extends View implements Drawable.Callback {
         }
     }
 
-    private void applyThemeStyle() {
+    private void applyConfiguredStyle() {
         if (manualStyle) {
             return;
         }
-        int desired = Theme.isCurrentThemeMonet()
+        int desired = AppearanceConfig.newLoadingStyle()
                 ? (noProgress ? M3CircularProgress.STYLE_LOADING_INDICATOR : M3CircularProgress.STYLE_WAVY)
                 : M3CircularProgress.STYLE_LEGACY;
-        if (desired == themeStyle) {
+        if (desired == configuredStyle) {
             return;
         }
-        themeStyle = desired;
+        configuredStyle = desired;
         if (!trackColorCustom) {
             trackColor = Theme.multAlpha(progressColor, 0.2f);
         }
@@ -369,7 +370,7 @@ public class RadialProgressView extends View implements Drawable.Callback {
     }
 
     private void drawArc(Canvas canvas) {
-        applyThemeStyle();
+        applyConfiguredStyle();
         drawingCircleLenght = currentCircleLength;
         if (currentStyle == M3CircularProgress.STYLE_LOADING_INDICATOR && m3Drawable != null) {
             m3Drawable.setBounds((int) cicleRect.left, (int) cicleRect.top,

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/RadialProgressView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/RadialProgressView.java
@@ -66,7 +66,7 @@ public class RadialProgressView extends View implements Drawable.Callback {
     private boolean trackColorCustom;
     private M3CircularProgress m3;
     // Автовыбор стиля по теме: на Monet спиннеры — LoadingIndicator (морф-фигура),
-    // детерминированный прогресс — CircularProgressIndicator (дуга с дорожкой).
+    // детерминированный прогресс — волнистая дуга с дорожкой (CircularProgressIndicator + волна).
     private int themeStyle = -1;
     private boolean manualStyle;
 
@@ -313,7 +313,7 @@ public class RadialProgressView extends View implements Drawable.Callback {
             return;
         }
         int desired = Theme.isCurrentThemeMonet()
-                ? (noProgress ? M3CircularProgress.STYLE_LOADING_INDICATOR : M3CircularProgress.STYLE_CIRCULAR)
+                ? (noProgress ? M3CircularProgress.STYLE_LOADING_INDICATOR : M3CircularProgress.STYLE_WAVY)
                 : M3CircularProgress.STYLE_LEGACY;
         if (desired == themeStyle) {
             return;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/chat/buttons/ChatActivityBlurredRoundButton.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/chat/buttons/ChatActivityBlurredRoundButton.java
@@ -131,7 +131,9 @@ public class ChatActivityBlurredRoundButton extends FrameLayout implements Facto
                 return;
             }
 
-            loadingIndicatorDrawable = new CircularProgressDrawable(AndroidUtilities.dp(18), AndroidUtilities.dp(1.7f), 0xFF757575);
+            loadingIndicatorDrawable = new CircularProgressDrawable(
+                    AndroidUtilities.dp(18), AndroidUtilities.dp(1.7f),
+                    Theme.multAlpha(0xFF757575, .25f), 0xFF757575);
             loadingIndicatorDrawable.setAngleOffset(90);
 
             loadingIndicatorView = new ImageView(getContext());

--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
@@ -359,6 +359,7 @@ import tw.nekomimi.nekogram.utils.AndroidUtil;
 import tw.nekomimi.nekogram.utils.ProxyUtil;
 import xyz.nextalone.nagram.NaConfig;
 
+import app.exteraless.appearance.M3CircularProgress;
 import app.exteraless.utils.VideoSubtitlesHelper;
 import tw.nekomimi.nekogram.helpers.MessageHelper;
 import tw.nekomimi.nekogram.streaming.MediaStreamingProvider;
@@ -6383,6 +6384,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
             }
         };
         miniProgressView.setUseSelfAlpha(true);
+        miniProgressView.setStyle(M3CircularProgress.STYLE_CIRCULAR);
         miniProgressView.setProgressColor(0xffffffff);
         miniProgressView.setSize(dp(54));
         miniProgressView.setBackgroundResource(R.drawable.circle_big);
@@ -6393,6 +6395,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
         createVideoControlsInterface();
 
         progressView = new RadialProgressView(parentActivity, resourcesProvider);
+        progressView.setStyle(M3CircularProgress.STYLE_CIRCULAR);
         progressView.setProgressColor(0xffffffff);
         progressView.setBackgroundResource(R.drawable.circle_big);
         progressView.setVisibility(View.INVISIBLE);

--- a/TMessagesProj/src/main/res/values-es/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values-es/strings_oe_appearance.xml
@@ -91,7 +91,7 @@
     <string name="OEMainMenuAddDivider">Añadir separador</string>
     <string name="OEMainMenuDivider">Separador</string>
     <string name="OEMainMenuRemoveSettingsInfo">No se pueden ocultar los Ajustes mientras la barra de navegación inferior está desactivada.</string>
-    <string name="OEAppearanceNewLoadingStyle">Estilo de carga</string>
+    <string name="OEAppearanceNewLoadingStyle">Cargadores MD3</string>
     <string name="OEAppearanceNewChatHeaderStyle">Encabezado del chat</string>
     <string name="OEAppearanceNewNavigationBarStyle">Barra de navegación inferior</string>
     <string name="OEAppearanceIosNavigationBarStyle">Barra de navegación inferior</string>

--- a/TMessagesProj/src/main/res/values-pl-rPL/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values-pl-rPL/strings_oe_appearance.xml
@@ -91,7 +91,7 @@
     <string name="OEMainMenuAddDivider">Dodaj separator</string>
     <string name="OEMainMenuDivider">Separator</string>
     <string name="OEMainMenuRemoveSettingsInfo">Nie można ukryć Ustawień, gdy dolny pasek nawigacji jest wyłączony.</string>
-    <string name="OEAppearanceNewLoadingStyle">Styl ładowania</string>
+    <string name="OEAppearanceNewLoadingStyle">Wskaźniki MD3</string>
     <string name="OEAppearanceNewChatHeaderStyle">Nagłówek czatu</string>
     <string name="OEAppearanceNewNavigationBarStyle">Dolny pasek nawigacji</string>
     <string name="OEAppearanceIosNavigationBarStyle">Dolny pasek nawigacji</string>

--- a/TMessagesProj/src/main/res/values-ru-rRU/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values-ru-rRU/strings_oe_appearance.xml
@@ -99,7 +99,7 @@
     <string name="OEBottomNavigationModeShow">Показывать</string>
     <string name="OEBottomNavigationModeHide">Скрывать</string>
     <string name="OEBackAnimationInfo">Плавнее переключает экраны и открывает боковое меню.</string>
-    <string name="OEAppearanceNewLoadingStyle">Стиль загрузки</string>
+    <string name="OEAppearanceNewLoadingStyle">MD3-лоадеры</string>
     <string name="OEAppearanceNewChatHeaderStyle">Шапка чата</string>
     <string name="OEAppearanceNewNavigationBarStyle">Нижняя панель навигации</string>
     <string name="OEAppearanceIosDesign" translatable="false">iOS Design</string>

--- a/TMessagesProj/src/main/res/values-zh-rCN/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values-zh-rCN/strings_oe_appearance.xml
@@ -91,7 +91,7 @@
     <string name="OEMainMenuAddDivider">添加分隔线</string>
     <string name="OEMainMenuDivider">分隔线</string>
     <string name="OEMainMenuRemoveSettingsInfo">底部导航栏关闭时无法隐藏「设置」。</string>
-    <string name="OEAppearanceNewLoadingStyle">加载动画样式</string>
+    <string name="OEAppearanceNewLoadingStyle">MD3 加载指示器</string>
     <string name="OEAppearanceNewChatHeaderStyle">对话顶栏</string>
     <string name="OEAppearanceNewNavigationBarStyle">底部导航栏</string>
     <string name="OEAppearanceIosNavigationBarStyle">底部导航栏</string>

--- a/TMessagesProj/src/main/res/values/strings_oe_appearance.xml
+++ b/TMessagesProj/src/main/res/values/strings_oe_appearance.xml
@@ -109,7 +109,7 @@
     <string name="OEMainMenuAddDivider">Add Divider</string>
     <string name="OEMainMenuDivider">Divider</string>
     <string name="OEMainMenuRemoveSettingsInfo">Settings cannot be hidden while the bottom navigation bar is disabled.</string>
-    <string name="OEAppearanceNewLoadingStyle">Loading Style</string>
+    <string name="OEAppearanceNewLoadingStyle">MD3 Loaders</string>
     <string name="OEAppearanceNewChatHeaderStyle">Chat Header</string>
     <string name="OEAppearanceNewNavigationBarStyle">Bottom Navigation Bar</string>
     <string name="OEAppearanceIosDesign" translatable="false">iOS Design</string>


### PR DESCRIPTION
All loaders switch to the Material 3 Expressive set when the "MD3 Loaders" toggle (exteraless -> Appearance -> MD3 styles) is on:

- indeterminate spinners become the morphing shape LoadingIndicator
- determinate progress uses the wavy arc with visible track and gap
- video player spinners use the plain ring loader instead of morphing shapes
- the blurred page-down button loader now renders correctly (it was built through the morph-style constructor whose drawable never rendered as a view background)

With the toggle off every loader stays stock Telegram, on any theme.