### PR TITLE
pill stack: add own pills (ram, cpu, net speed, dc ping, gold, eth, eur)

### DIFF
--- a/TMessagesProj/src/main/java/app/exteraless/backup/EtgBackup.java
+++ b/TMessagesProj/src/main/java/app/exteraless/backup/EtgBackup.java
@@ -434,6 +434,9 @@ public final class EtgBackup {
         text(list, SECTION_EXTERA, "gramTargetCurrency", PillStackConfig.gramTargetCurrency, EtgBackup::isCurrency);
         text(list, SECTION_EXTERA, "btcTargetCurrency", PillStackConfig.btcTargetCurrency, EtgBackup::isCurrency);
         text(list, SECTION_EXTERA, "usdTargetCurrency", PillStackConfig.usdTargetCurrency, EtgBackup::isCurrency);
+        text(list, SECTION_EXTERA, "ethTargetCurrency", PillStackConfig.ethTargetCurrency, EtgBackup::isCurrency);
+        text(list, SECTION_EXTERA, "eurTargetCurrency", PillStackConfig.eurTargetCurrency, EtgBackup::isCurrency);
+        text(list, SECTION_EXTERA, "goldTargetCurrency", PillStackConfig.goldTargetCurrency, EtgBackup::isCurrency);
         text(list, SECTION_PILLS, "activePills", PillStackConfig.activePillsRaw, EtgBackup::isPillsLayout);
         text(list, SECTION_PILLS, "hiddenPills", PillStackConfig.hiddenPillsRaw, EtgBackup::isPillsLayout);
 

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/ExchangeRates.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/ExchangeRates.java
@@ -54,7 +54,8 @@ public class ExchangeRates {
         @Override
         public void onPillStackSettingsChanged(int[] pillIds) {
             if (PillStackEvents.shouldUpdatePill(pillIds,
-                    PillType.GRAM.id, PillType.BTC.id, PillType.USD.id)) {
+                    PillType.GRAM.id, PillType.BTC.id, PillType.USD.id,
+                    PillType.ETH.id, PillType.EUR.id, PillType.GOLD.id)) {
                 clearCache();
             }
         }

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/GoldPrice.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/GoldPrice.java
@@ -1,0 +1,146 @@
+package app.exteraless.pillstack;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONObject;
+import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.FileLog;
+import org.telegram.messenger.Utilities;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import tw.nekomimi.nekogram.utils.HttpClient;
+
+/**
+ * Спотовая цена золота с gold-api.com (бесплатный эндпоинт без ключа).
+ * Храним одно число — цену тройской унции в USD — с кэшем и склейкой
+ * параллельных запросов, как в {@link ExchangeRates}.
+ */
+public class GoldPrice {
+
+    private static final String URL = "https://api.gold-api.com/price/XAU";
+    private static final long CACHE_TTL = 5 * 60 * 1000L;
+
+    private static final Object sync = new Object();
+    private static final ArrayList<Utilities.Callback<BigDecimal>> pendingCallbacks = new ArrayList<>();
+    private static boolean requestInFlight;
+    private static BigDecimal cacheValue;
+    private static long cacheTimestamp;
+
+    public static void clearCache() {
+        cacheTimestamp = 0;
+    }
+
+    public static BigDecimal getCached() {
+        if (cacheValue == null) {
+            try {
+                String raw = PillStackConfig.goldPriceCache.String();
+                if (raw != null && !raw.isEmpty()) {
+                    cacheValue = new BigDecimal(raw);
+                    cacheTimestamp = PillStackConfig.goldPriceCacheTime.Long();
+                }
+            } catch (Exception e) {
+                FileLog.e(e);
+            }
+        }
+        return cacheValue;
+    }
+
+    private static boolean isStale() {
+        return getCached() == null || cacheTimestamp == 0 || System.currentTimeMillis() - cacheTimestamp >= CACHE_TTL;
+    }
+
+    public static void fetch(Utilities.Callback<BigDecimal> callback) {
+        if (callback == null) {
+            return;
+        }
+        final BigDecimal cached = getCached();
+        if (cached != null && !isStale()) {
+            AndroidUtilities.runOnUIThread(() -> callback.run(cached));
+            return;
+        }
+        boolean startRequest;
+        synchronized (sync) {
+            pendingCallbacks.add(callback);
+            startRequest = !requestInFlight;
+            requestInFlight = true;
+        }
+        if (!startRequest) {
+            return;
+        }
+        try {
+            HttpClient.INSTANCE.getInstance()
+                    .newCall(new Request.Builder().url(URL).build())
+                    .enqueue(new Callback() {
+                        @Override
+                        public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                            FileLog.e(e);
+                            complete(getCached());
+                        }
+
+                        @Override
+                        public void onResponse(@NonNull Call call, @NonNull Response response) {
+                            try (ResponseBody body = response.body()) {
+                                if (!response.isSuccessful() || body == null) {
+                                    complete(getCached());
+                                    return;
+                                }
+                                BigDecimal price = parse(body.string());
+                                if (price != null) {
+                                    cacheValue = price;
+                                    cacheTimestamp = System.currentTimeMillis();
+                                    saveCache(price);
+                                }
+                                complete(price != null ? price : getCached());
+                            } catch (Exception e) {
+                                FileLog.e(e);
+                                complete(getCached());
+                            }
+                        }
+                    });
+        } catch (Exception e) {
+            FileLog.e(e);
+            complete(getCached());
+        }
+    }
+
+    private static void complete(BigDecimal price) {
+        final ArrayList<Utilities.Callback<BigDecimal>> callbacks;
+        synchronized (sync) {
+            requestInFlight = false;
+            callbacks = new ArrayList<>(pendingCallbacks);
+            pendingCallbacks.clear();
+        }
+        AndroidUtilities.runOnUIThread(() -> {
+            for (Utilities.Callback<BigDecimal> callback : callbacks) {
+                callback.run(price);
+            }
+        });
+    }
+
+    private static BigDecimal parse(String json) {
+        try {
+            double price = new JSONObject(json).optDouble("price", 0);
+            return price > 0 ? BigDecimal.valueOf(price) : null;
+        } catch (Exception e) {
+            FileLog.e(e);
+            return null;
+        }
+    }
+
+    private static void saveCache(BigDecimal price) {
+        try {
+            PillStackConfig.goldPriceCache.setConfigString(price.toPlainString());
+            PillStackConfig.goldPriceCacheTime.setConfigLong(System.currentTimeMillis());
+        } catch (Exception e) {
+            FileLog.e(e);
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/PillRegistry.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/PillRegistry.java
@@ -19,9 +19,16 @@ import java.util.Map;
 import app.exteraless.pillstack.pills.BasePill;
 import app.exteraless.pillstack.pills.BtcPill;
 import app.exteraless.pillstack.pills.CachePill;
+import app.exteraless.pillstack.pills.CpuPill;
+import app.exteraless.pillstack.pills.DcPingPill;
+import app.exteraless.pillstack.pills.EthPill;
+import app.exteraless.pillstack.pills.EurPill;
 import app.exteraless.pillstack.pills.GhostPill;
+import app.exteraless.pillstack.pills.GoldPill;
 import app.exteraless.pillstack.pills.GramPill;
+import app.exteraless.pillstack.pills.NetSpeedPill;
 import app.exteraless.pillstack.pills.ProxyPill;
+import app.exteraless.pillstack.pills.RamPill;
 import app.exteraless.pillstack.pills.UsdPill;
 import app.exteraless.pillstack.pills.WeatherPill;
 
@@ -120,6 +127,34 @@ public class PillRegistry {
                 R.drawable.ayu_ghost,
                 IconBackgroundColors.PURPLE.top, IconBackgroundColors.PURPLE.bottom,
                 GhostPill::new));
+        register(new PillInfo(PillType.RAM.id, LocaleController.getString(R.string.PillStackRam),
+                R.drawable.pillstack_ram,
+                IconBackgroundColors.CYAN.top, IconBackgroundColors.CYAN.bottom,
+                RamPill::new));
+        register(new PillInfo(PillType.CPU.id, LocaleController.getString(R.string.PillStackCpu),
+                R.drawable.pillstack_cpu,
+                IconBackgroundColors.RED.top, IconBackgroundColors.RED.bottom,
+                CpuPill::new));
+        register(new PillInfo(PillType.NET_SPEED.id, LocaleController.getString(R.string.PillStackNetSpeed),
+                R.drawable.pillstack_netspeed,
+                IconBackgroundColors.BLUE.top, IconBackgroundColors.BLUE.bottom,
+                NetSpeedPill::new));
+        register(new PillInfo(PillType.DC_PING.id, LocaleController.getString(R.string.PillStackDcPing),
+                R.drawable.pillstack_ping,
+                IconBackgroundColors.GREEN.top, IconBackgroundColors.GREEN.bottom,
+                DcPingPill::new));
+        register(new PillInfo(PillType.GOLD.id, LocaleController.getString(R.string.PillStackGold),
+                R.drawable.pillstack_gold,
+                IconBackgroundColors.ORANGE.top, IconBackgroundColors.ORANGE.bottom,
+                GoldPill::new));
+        register(new PillInfo(PillType.ETH.id, "ETH",
+                R.drawable.pillstack_eth,
+                IconBackgroundColors.PURPLE.top, IconBackgroundColors.PURPLE.bottom,
+                EthPill::new));
+        register(new PillInfo(PillType.EUR.id, "EUR",
+                R.drawable.pillstack_eur,
+                IconBackgroundColors.BLUE_DEEP.top, IconBackgroundColors.BLUE_DEEP.bottom,
+                EurPill::new));
     }
 
     // ---- Пакетная регистрация ----

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/PillType.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/PillType.java
@@ -12,7 +12,15 @@ public enum PillType {
     CACHE(5),
     PROXY(6),
     /** Идентификатора в exteraGram нет — пилюля наша, поэтому номер после последнего чужого. */
-    GHOST(7);
+    GHOST(7),
+    // Собственные пилюли exteraless, номера дальше по порядку.
+    RAM(8),
+    CPU(9),
+    NET_SPEED(10),
+    DC_PING(11),
+    GOLD(12),
+    ETH(13),
+    EUR(14);
 
     public final int id;
 

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/CpuPill.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/CpuPill.java
@@ -1,0 +1,89 @@
+package app.exteraless.pillstack.pills;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+
+import org.telegram.messenger.FileLog;
+import org.telegram.messenger.R;
+import org.telegram.ui.ActionBar.Theme;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+
+import app.exteraless.pillstack.PillType;
+
+/**
+ * Загрузка CPU в процентах по /proc/stat: доля занятых тиков между двумя замерами.
+ * Первый замер только запоминает базу — процента до второго замера нет.
+ */
+@SuppressLint("ViewConstructor")
+public class CpuPill extends TelemetryPill {
+
+    private static long previousTotal = -1;
+    private static long previousIdle;
+
+    public CpuPill(Context context, Theme.ResourcesProvider resourcesProvider) {
+        super(context, resourcesProvider, R.drawable.pillstack_cpu);
+    }
+
+    @Override
+    public int getPillId() {
+        return PillType.CPU.id;
+    }
+
+    @Override
+    public long getRefreshInterval() {
+        return 3_000L;
+    }
+
+    @Override
+    protected String measureText() {
+        try {
+            long[] stat = readCpuStat();
+            if (stat == null) {
+                return null;
+            }
+            long idle = stat[0];
+            long total = stat[1];
+            if (previousTotal < 0) {
+                previousIdle = idle;
+                previousTotal = total;
+                return null;
+            }
+            long deltaTotal = total - previousTotal;
+            long deltaIdle = idle - previousIdle;
+            previousIdle = idle;
+            previousTotal = total;
+            if (deltaTotal <= 0) {
+                return null;
+            }
+            long percent = (deltaTotal - deltaIdle) * 100 / deltaTotal;
+            return Math.max(0, Math.min(percent, 100)) + "%";
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** [0] — idle+iowait, [1] — сумма всех тиков. */
+    private static long[] readCpuStat() {
+        try (BufferedReader reader = new BufferedReader(new FileReader("/proc/stat"))) {
+            String line = reader.readLine();
+            if (line == null || !line.startsWith("cpu ")) {
+                return null;
+            }
+            String[] parts = line.trim().split("\\s+");
+            if (parts.length < 8) {
+                return null;
+            }
+            long total = 0;
+            for (int i = 1; i <= 8 && i < parts.length; i++) {
+                total += Long.parseLong(parts[i]);
+            }
+            long idle = Long.parseLong(parts[4]) + Long.parseLong(parts[5]);
+            return new long[]{idle, total};
+        } catch (Exception e) {
+            FileLog.e(e);
+            return null;
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/DcPingPill.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/DcPingPill.java
@@ -1,0 +1,47 @@
+package app.exteraless.pillstack.pills;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+
+import org.telegram.messenger.LocaleController;
+import org.telegram.messenger.R;
+import org.telegram.messenger.UserConfig;
+import org.telegram.tgnet.ConnectionsManager;
+import org.telegram.ui.ActionBar.Theme;
+
+import app.exteraless.pillstack.PillType;
+
+/**
+ * Пинг до дата-центра текущего аккаунта. Число берём у нативного MTProto-соединения
+ * ({@code native_getCurrentPingTime}) — никаких своих сокетов не открываем.
+ */
+@SuppressLint("ViewConstructor")
+public class DcPingPill extends TelemetryPill {
+
+    public DcPingPill(Context context, Theme.ResourcesProvider resourcesProvider) {
+        super(context, resourcesProvider, R.drawable.pillstack_ping);
+    }
+
+    @Override
+    public int getPillId() {
+        return PillType.DC_PING.id;
+    }
+
+    @Override
+    public long getRefreshInterval() {
+        return 5_000L;
+    }
+
+    @Override
+    protected String measureText() {
+        try {
+            int ping = ConnectionsManager.native_getCurrentPingTime(UserConfig.selectedAccount);
+            if (ping <= 0) {
+                return null;
+            }
+            return LocaleController.formatString(R.string.PillStackDcPingValue, ping);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/EthPill.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/EthPill.java
@@ -1,0 +1,39 @@
+package app.exteraless.pillstack.pills;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+
+import org.telegram.messenger.R;
+import org.telegram.ui.ActionBar.Theme;
+import org.telegram.ui.Components.IconBackgroundColors;
+
+import app.exteraless.pillstack.PillStackConfig;
+import app.exteraless.pillstack.PillType;
+
+/** Курс Ethereum. */
+@SuppressLint("ViewConstructor")
+public class EthPill extends RatePill {
+
+    private static final RateCache CACHE = new RateCache();
+
+    public EthPill(Context context, Theme.ResourcesProvider resourcesProvider) {
+        super(context, resourcesProvider, CACHE, "ETH", 2, R.drawable.pillstack_eth,
+                new ColoredBackground(IconBackgroundColors.BLUE_DEEP.top,
+                        IconBackgroundColors.BLUE_DEEP.bottom));
+    }
+
+    @Override
+    public int getPillId() {
+        return PillType.ETH.id;
+    }
+
+    @Override
+    public String getTargetSelection() {
+        return PillStackConfig.ethTargetCurrency.String();
+    }
+
+    @Override
+    public void setTargetSelection(String currency) {
+        PillStackConfig.ethTargetCurrency.setConfigString(currency);
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/EurPill.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/EurPill.java
@@ -1,0 +1,46 @@
+package app.exteraless.pillstack.pills;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+
+import org.telegram.messenger.R;
+import org.telegram.ui.ActionBar.Theme;
+import org.telegram.ui.Components.IconBackgroundColors;
+
+import app.exteraless.pillstack.PillCurrencies;
+import app.exteraless.pillstack.PillStackConfig;
+import app.exteraless.pillstack.PillType;
+
+/** Курс евро к выбранной валюте. EUR в списке целей смысла не имеет. */
+@SuppressLint("ViewConstructor")
+public class EurPill extends RatePill {
+
+    private static final RateCache CACHE = new RateCache();
+
+    public EurPill(Context context, Theme.ResourcesProvider resourcesProvider) {
+        super(context, resourcesProvider, CACHE, "EUR", 2, R.drawable.pillstack_eur,
+                new ColoredBackground(IconBackgroundColors.BLUE.top,
+                        IconBackgroundColors.BLUE.bottom));
+    }
+
+    @Override
+    public int getPillId() {
+        return PillType.EUR.id;
+    }
+
+    @Override
+    public String[] getTargetCurrencies() {
+        return PillCurrencies.getTargetCurrencies("EUR");
+    }
+
+    @Override
+    public String getTargetSelection() {
+        String selection = PillStackConfig.eurTargetCurrency.String();
+        return "EUR".equalsIgnoreCase(selection) ? PillCurrencies.AUTO : selection;
+    }
+
+    @Override
+    public void setTargetSelection(String currency) {
+        PillStackConfig.eurTargetCurrency.setConfigString(currency);
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/GoldPill.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/GoldPill.java
@@ -1,0 +1,69 @@
+package app.exteraless.pillstack.pills;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+
+import org.telegram.messenger.R;
+import org.telegram.messenger.Utilities;
+import org.telegram.ui.ActionBar.Theme;
+import org.telegram.ui.Components.IconBackgroundColors;
+
+import java.math.BigDecimal;
+
+import app.exteraless.pillstack.ExchangeRates;
+import app.exteraless.pillstack.GoldPrice;
+import app.exteraless.pillstack.PillStackConfig;
+import app.exteraless.pillstack.PillType;
+
+/**
+ * Цена золота за тройскую унцию. Спот приходит в USD с gold-api.com,
+ * в целевую валюту конвертируем через обычные курсы {@link ExchangeRates}.
+ */
+@SuppressLint("ViewConstructor")
+public class GoldPill extends RatePill {
+
+    private static final RateCache CACHE = new RateCache();
+
+    public GoldPill(Context context, Theme.ResourcesProvider resourcesProvider) {
+        super(context, resourcesProvider, CACHE, "XAU", 2, R.drawable.pillstack_gold,
+                new ColoredBackground(IconBackgroundColors.ORANGE.top,
+                        IconBackgroundColors.ORANGE.bottom));
+    }
+
+    @Override
+    public int getPillId() {
+        return PillType.GOLD.id;
+    }
+
+    @Override
+    public String getTargetSelection() {
+        return PillStackConfig.goldTargetCurrency.String();
+    }
+
+    @Override
+    public void setTargetSelection(String currency) {
+        PillStackConfig.goldTargetCurrency.setConfigString(currency);
+    }
+
+    @Override
+    protected void fetchRate(String target, boolean force, Utilities.Callback<BigDecimal> callback) {
+        if (force) {
+            GoldPrice.clearCache();
+            ExchangeRates.clearCache();
+        }
+        GoldPrice.fetch(usdPrice -> {
+            if (usdPrice == null) {
+                callback.run(null);
+                return;
+            }
+            if ("USD".equals(target)) {
+                callback.run(usdPrice);
+                return;
+            }
+            ExchangeRates.fetch(state -> {
+                BigDecimal conversion = state == null ? null : state.getRate("USD", target);
+                callback.run(conversion == null ? null : usdPrice.multiply(conversion));
+            });
+        });
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/NetSpeedPill.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/NetSpeedPill.java
@@ -1,0 +1,67 @@
+package app.exteraless.pillstack.pills;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.net.TrafficStats;
+import android.os.SystemClock;
+
+import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.R;
+import org.telegram.ui.ActionBar.Theme;
+
+import app.exteraless.pillstack.PillType;
+
+/**
+ * Текущая скорость сети: дельта TrafficStats между замерами.
+ * Показываем доминирующее направление: «↓1.2 MB/s» или «↑340 KB/s».
+ */
+@SuppressLint("ViewConstructor")
+public class NetSpeedPill extends TelemetryPill {
+
+    private static long previousRx = -1;
+    private static long previousTx;
+    private static long previousTime;
+
+    public NetSpeedPill(Context context, Theme.ResourcesProvider resourcesProvider) {
+        super(context, resourcesProvider, R.drawable.pillstack_netspeed);
+    }
+
+    @Override
+    public int getPillId() {
+        return PillType.NET_SPEED.id;
+    }
+
+    @Override
+    public long getRefreshInterval() {
+        return 2_000L;
+    }
+
+    @Override
+    protected String measureText() {
+        long rx = TrafficStats.getTotalRxBytes();
+        long tx = TrafficStats.getTotalTxBytes();
+        if (rx == TrafficStats.UNSUPPORTED || tx == TrafficStats.UNSUPPORTED) {
+            return null;
+        }
+        long now = SystemClock.elapsedRealtime();
+        if (previousRx < 0) {
+            previousRx = rx;
+            previousTx = tx;
+            previousTime = now;
+            return null;
+        }
+        long elapsed = now - previousTime;
+        if (elapsed <= 0) {
+            return null;
+        }
+        long rxSpeed = Math.max(0, rx - previousRx) * 1000 / elapsed;
+        long txSpeed = Math.max(0, tx - previousTx) * 1000 / elapsed;
+        previousRx = rx;
+        previousTx = tx;
+        previousTime = now;
+        if (rxSpeed >= txSpeed) {
+            return "↓" + AndroidUtilities.formatFileSize(rxSpeed) + "/s";
+        }
+        return "↑" + AndroidUtilities.formatFileSize(txSpeed) + "/s";
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/RamPill.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/RamPill.java
@@ -1,0 +1,45 @@
+package app.exteraless.pillstack.pills;
+
+import android.annotation.SuppressLint;
+import android.app.ActivityManager;
+import android.content.Context;
+
+import org.telegram.messenger.R;
+import org.telegram.ui.ActionBar.Theme;
+
+import app.exteraless.pillstack.PillType;
+
+/** Занятость оперативной памяти в процентах. */
+@SuppressLint("ViewConstructor")
+public class RamPill extends TelemetryPill {
+
+    public RamPill(Context context, Theme.ResourcesProvider resourcesProvider) {
+        super(context, resourcesProvider, R.drawable.pillstack_ram);
+    }
+
+    @Override
+    public int getPillId() {
+        return PillType.RAM.id;
+    }
+
+    @Override
+    public long getRefreshInterval() {
+        return 3_000L;
+    }
+
+    @Override
+    protected String measureText() {
+        try {
+            ActivityManager manager = (ActivityManager) getContext().getSystemService(Context.ACTIVITY_SERVICE);
+            ActivityManager.MemoryInfo info = new ActivityManager.MemoryInfo();
+            manager.getMemoryInfo(info);
+            if (info.totalMem <= 0) {
+                return null;
+            }
+            long used = info.totalMem - info.availMem;
+            return (used * 100 / info.totalMem) + "%";
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/RatePill.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/RatePill.java
@@ -11,6 +11,7 @@ import android.widget.LinearLayout;
 import org.telegram.messenger.AndroidUtilities;
 import org.telegram.messenger.LocaleController;
 import org.telegram.messenger.R;
+import org.telegram.messenger.Utilities;
 import org.telegram.ui.ActionBar.ActionBarMenuSubItem;
 import org.telegram.ui.ActionBar.BaseFragment;
 import org.telegram.ui.ActionBar.Theme;
@@ -92,6 +93,18 @@ public abstract class RatePill extends BasePill implements PillStackEvents.Liste
 
     public abstract void setTargetSelection(String currency);
 
+    /**
+     * Источник курса «сколько target стоит одна единица базы». По умолчанию курсы
+     * {@link ExchangeRates}; пилюли с внешним источником (золото) переопределяют.
+     */
+    protected void fetchRate(String target, boolean force, Utilities.Callback<BigDecimal> callback) {
+        if (force) {
+            ExchangeRates.clearCache();
+        }
+        ExchangeRates.fetch(state ->
+                callback.run(state == null ? null : state.getRate(baseCurrency, target)));
+    }
+
     public String[] getTargetCurrencies() {
         return PillCurrencies.TARGET_CURRENCIES;
     }
@@ -151,12 +164,8 @@ public abstract class RatePill extends BasePill implements PillStackEvents.Liste
             iconView.setVisibility(VISIBLE);
             textView.setVisibility(VISIBLE);
         }
-        if (force) {
-            ExchangeRates.clearCache();
-        }
-        ExchangeRates.fetch(state -> {
+        fetchRate(target, force, rate -> {
             requestInFlight = false;
-            BigDecimal rate = state == null ? null : state.getRate(baseCurrency, target);
             if (rate == null) {
                 String fallback = cache.cachedPrice.get();
                 if (fallback != null) {

--- a/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/TelemetryPill.java
+++ b/TMessagesProj/src/main/java/app/exteraless/pillstack/pills/TelemetryPill.java
@@ -1,0 +1,126 @@
+package app.exteraless.pillstack.pills;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+
+import org.telegram.messenger.AndroidUtilities;
+import org.telegram.messenger.LocaleController;
+import org.telegram.messenger.R;
+import org.telegram.ui.ActionBar.BaseFragment;
+import org.telegram.ui.ActionBar.Theme;
+import org.telegram.ui.Components.AnimatedTextView;
+import org.telegram.ui.Components.ItemOptions;
+import org.telegram.ui.Components.LayoutHelper;
+import org.telegram.ui.Components.ScaleStateListAnimator;
+import org.telegram.ui.LaunchActivity;
+
+import app.exteraless.pillstack.PillStackSettingsActivity;
+
+/**
+ * База для пилюль локальной телеметрии (RAM, CPU, сеть, пинг): нейтральный фон
+ * как у кэша/прокси, текст замеряется локально без сети, тап — обновить.
+ */
+@SuppressLint("ViewConstructor")
+public abstract class TelemetryPill extends BasePill {
+
+    private final LinearLayout layout;
+    private final ImageView iconView;
+    private final AnimatedTextView textView;
+
+    public TelemetryPill(Context context, Theme.ResourcesProvider resourcesProvider, int iconResId) {
+        super(context, resourcesProvider);
+
+        layout = new LinearLayout(context);
+        layout.setOrientation(LinearLayout.HORIZONTAL);
+        layout.setGravity(Gravity.CENTER);
+        layout.setMinimumWidth(AndroidUtilities.dp(48));
+        layout.setPadding(AndroidUtilities.dp(8), 0, AndroidUtilities.dp(8), 0);
+        addView(layout, LayoutHelper.createFrame(LayoutHelper.WRAP_CONTENT, 28,
+                (LocaleController.isRTL ? Gravity.LEFT : Gravity.RIGHT) | Gravity.CENTER_VERTICAL));
+
+        iconView = new ImageView(context);
+        iconView.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+        iconView.setImageResource(iconResId);
+        layout.addView(iconView, LayoutHelper.createLinear(16, 16, Gravity.CENTER_VERTICAL, 0, 0, 4, 0));
+
+        textView = new AnimatedTextView(context, true, true, true);
+        textView.setTextSize(AndroidUtilities.dp(13));
+        textView.setTypeface(AndroidUtilities.bold());
+        textView.setIncludeFontPadding(false);
+        textView.adaptWidth = true;
+        layout.addView(textView, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT, Gravity.CENTER_VERTICAL));
+
+        setLoadingTargetView(layout);
+        updateColors();
+        ScaleStateListAnimator.apply(layout);
+    }
+
+    /** Снять замер и вернуть текст пилюли; null — данных ещё нет, покажем прочерк. */
+    protected abstract String measureText();
+
+    @Override
+    public void onUpdateData(boolean force) {
+        String measured = measureText();
+        String text = measured != null ? measured : "—";
+        CharSequence old = textView.getText();
+        if (old == null || !TextUtils.equals(old, text)) {
+            animateSizeChange();
+            textView.setText(text, true);
+        }
+        markDataUpdated();
+    }
+
+    @Override
+    public void onPillClicked() {
+        onUpdateData(true);
+    }
+
+    @Override
+    public boolean onPillLongClicked() {
+        BaseFragment fragment = LaunchActivity.getSafeLastFragment();
+        if (fragment == null) {
+            return false;
+        }
+        ItemOptions.makeOptions(fragment, this)
+                .add(R.drawable.msg_retry, LocaleController.getString(R.string.Refresh), () -> onUpdateData(true))
+                .add(R.drawable.msg_settings, LocaleController.getString(R.string.Settings),
+                        () -> fragment.presentFragment(new PillStackSettingsActivity()))
+                .setDrawScrim(false)
+                .setDimAlpha(0)
+                .show();
+        return true;
+    }
+
+    @Override
+    public void drawableHotspotChanged(float x, float y) {
+        if (loading) {
+            return;
+        }
+        super.drawableHotspotChanged(x, y);
+        layout.drawableHotspotChanged(x - layout.getLeft(), y - layout.getTop());
+    }
+
+    @Override
+    public void setPressed(boolean pressed) {
+        if (loading) {
+            pressed = false;
+        }
+        super.setPressed(pressed);
+        layout.setPressed(pressed);
+    }
+
+    @Override
+    public void updateColors() {
+        int color = getThemedColor(Theme.key_windowBackgroundWhiteBlackText, 0.75f);
+        layout.setBackground(Theme.createSimpleSelectorRoundRectDrawable(AndroidUtilities.dp(14),
+                Theme.isCurrentThemeDark() ? getThemedColor(Theme.key_windowBackgroundWhite) : Theme.multAlpha(color, 0.09f),
+                Theme.multAlpha(color, 0.1f)));
+        textView.setTextColor(color);
+        iconView.setColorFilter(color);
+        updateLoadingColors();
+    }
+}

--- a/TMessagesProj/src/main/kotlin/app/exteraless/pillstack/PillStackConfig.kt
+++ b/TMessagesProj/src/main/kotlin/app/exteraless/pillstack/PillStackConfig.kt
@@ -58,6 +58,22 @@ object PillStackConfig {
     @JvmField
     val usdTargetCurrency = addConfig("OEPillUsdCurrency", ConfigItem.configTypeString, CURRENCY_AUTO)
 
+    @JvmField
+    val ethTargetCurrency = addConfig("OEPillEthCurrency", ConfigItem.configTypeString, CURRENCY_AUTO)
+
+    @JvmField
+    val eurTargetCurrency = addConfig("OEPillEurCurrency", ConfigItem.configTypeString, CURRENCY_AUTO)
+
+    @JvmField
+    val goldTargetCurrency = addConfig("OEPillGoldCurrency", ConfigItem.configTypeString, CURRENCY_AUTO)
+
+    /** Кэш цены золота (USD за унцию), чтобы переживать перезапуск приложения. */
+    @JvmField
+    val goldPriceCache = addConfig("OEPillGoldPriceCache", ConfigItem.configTypeString, "")
+
+    @JvmField
+    val goldPriceCacheTime = addConfig("OEPillGoldPriceCacheTime", ConfigItem.configTypeLong, 0L)
+
     /** Кэш ответа Coinbase: «CODE=rate,CODE=rate», курсы к USD. */
     @JvmField
     val ratesCache = addConfig("OEPillRatesCache", ConfigItem.configTypeString, "")

--- a/TMessagesProj/src/main/res/drawable/pillstack_cpu.xml
+++ b/TMessagesProj/src/main/res/drawable/pillstack_cpu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material Icons "memory" (CPU chip), Apache License 2.0 -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#ffffffff"
+        android:pathData="M15 9H9v6h6V9zm-2 4h-2v-2h2v2zm8-2V9h-2V7c0-1.1-.9-2-2-2h-2V3h-2v2h-2V3H9v2H7c-1.1 0-2 .9-2 2v2H3v2h2v2H3v2h2v2c0 1.1.9 2 2 2h2v2h2v-2h2v2h2v-2h2c1.1 0 2-.9 2-2v-2h2v-2h-2v-2h2zm-4 6H7V7h10v10z"/>
+</vector>

--- a/TMessagesProj/src/main/res/drawable/pillstack_eth.xml
+++ b/TMessagesProj/src/main/res/drawable/pillstack_eth.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Ethereum logo, Simple Icons (CC0 1.0) -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#ffffffff"
+        android:pathData="M11.944 17.97L4.58 13.62 11.943 24l7.37-10.38-7.372 4.35h.003zM12.056 0L4.69 12.223l7.365 4.354 7.365-4.35L12.056 0z"/>
+</vector>

--- a/TMessagesProj/src/main/res/drawable/pillstack_eur.xml
+++ b/TMessagesProj/src/main/res/drawable/pillstack_eur.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material Icons "euro", Apache License 2.0 -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#ffffffff"
+        android:pathData="M15 18.5A6.48 6.48 0 0 1 9.24 15H15l1-2H8.58c-.05-.33-.08-.66-.08-1s.03-.67.08-1H15l1-2H9.24A6.491 6.491 0 0 1 15 5.5c1.61 0 3.09.59 4.23 1.57L21 5.3A8.955 8.955 0 0 0 15 3c-3.92 0-7.24 2.51-8.48 6H3l-1 2h4.06a8.262 8.262 0 0 0 0 2H3l-1 2h4.52c1.24 3.49 4.56 6 8.48 6c2.31 0 4.41-.87 6-2.3l-1.78-1.77c-1.13.98-2.6 1.57-4.22 1.57z"/>
+</vector>

--- a/TMessagesProj/src/main/res/drawable/pillstack_gold.xml
+++ b/TMessagesProj/src/main/res/drawable/pillstack_gold.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material Symbols "toll" (coin), Apache License 2.0 -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="#ffffffff"
+            android:pathData="M373-253q-93-93-93-227t93-227q93-93 227-93t227 93q93 93 93 227t-93 227q-93 93-227 93t-227-93Zm-148 63q-84-39-134.5-117T40-480q0-95 50.5-173T225-770q21-10 38 1.5t17 37.5q0 10-6.5 19.5T257-697q-63 29-100 87.5T120-480q0 71 37 129.5T257-263q10 5 16.5 14t6.5 20q0 25-17 37t-38 2Zm375-290Zm170 170q70-70 70-170t-70-170q-70-70-170-70t-170 70q-70 70-70 170t70 170q70 70 170 70t170-70Z"/>
+    </group>
+</vector>

--- a/TMessagesProj/src/main/res/drawable/pillstack_netspeed.xml
+++ b/TMessagesProj/src/main/res/drawable/pillstack_netspeed.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material Icons "speed" (gauge), Apache License 2.0 -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#ffffffff"
+        android:pathData="M20.38 8.57l-1.23 1.85a8 8 0 0 1-.22 7.58H5.07A8 8 0 0 1 15.58 6.85l1.85-1.23A10 10 0 0 0 3.35 19a2 2 0 0 0 1.72 1h13.85a2 2 0 0 0 1.74-1a10 10 0 0 0-.27-10.44zm-9.79 6.84a2 2 0 0 0 2.83 0l5.66-8.49l-8.49 5.66a2 2 0 0 0 0 2.83z"/>
+</vector>

--- a/TMessagesProj/src/main/res/drawable/pillstack_ping.xml
+++ b/TMessagesProj/src/main/res/drawable/pillstack_ping.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material Icons "network_ping", Apache License 2.0 -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#ffffffff"
+        android:pathData="M12 14.67L3.41 6.09L2 7.5l8.5 8.5H4v2h16v-2h-6.5l5.15-5.15A2.5 2.5 0 1 0 19.5 6A2.5 2.5 0 0 0 17 8.5c0 .35.07.67.2.97l-5.2 5.2z"/>
+</vector>

--- a/TMessagesProj/src/main/res/drawable/pillstack_ram.xml
+++ b/TMessagesProj/src/main/res/drawable/pillstack_ram.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Material Symbols "memory_alt" (RAM module), Apache License 2.0 -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="#ffffffff"
+            android:pathData="M308.5-371.5Q320-383 320-400v-160q0-17-11.5-28.5T280-600q-17 0-28.5 11.5T240-560v160q0 17 11.5 28.5T280-360q17 0 28.5-11.5Zm200 0Q520-383 520-400v-160q0-17-11.5-28.5T480-600q-17 0-28.5 11.5T440-560v160q0 17 11.5 28.5T480-360q17 0 28.5-11.5Zm200 0Q720-383 720-400v-160q0-17-11.5-28.5T680-600q-17 0-28.5 11.5T640-560v160q0 17 11.5 28.5T680-360q17 0 28.5-11.5ZM160-280h640v-400H160v400Zm0 0v-400 400Zm0 80q-33 0-56.5-23.5T80-280v-400q0-33 23.5-56.5T160-760h40v-40q0-17 11.5-28.5T240-840q17 0 28.5 11.5T280-800v40h160v-40q0-17 11.5-28.5T480-840q17 0 28.5 11.5T520-800v40h160v-40q0-17 11.5-28.5T720-840q17 0 28.5 11.5T760-800v40h40q33 0 56.5 23.5T880-680v400q0 33-23.5 56.5T800-200h-40v40q0 17-11.5 28.5T720-120q-17 0-28.5-11.5T680-160v-40H520v40q0 17-11.5 28.5T480-120q-17 0-28.5-11.5T440-160v-40H280v40q0 17-11.5 28.5T240-120q-17 0-28.5-11.5T200-160v-40h-40Z"/>
+    </group>
+</vector>

--- a/TMessagesProj/src/main/res/values-ru-rRU/strings_oe_pill.xml
+++ b/TMessagesProj/src/main/res/values-ru-rRU/strings_oe_pill.xml
@@ -17,6 +17,13 @@
     <string name="PillStackProxy">Прокси</string>
     <string name="PillStackProxyPing">%1$d мс</string>
 
+    <string name="PillStackRam">ОЗУ</string>
+    <string name="PillStackCpu">Процессор</string>
+    <string name="PillStackNetSpeed">Скорость сети</string>
+    <string name="PillStackDcPing">Пинг DC</string>
+    <string name="PillStackDcPingValue">%1$d мс</string>
+    <string name="PillStackGold">Золото</string>
+
     <string name="CryptoPillTargetCurrency">Целевая валюта</string>
     <string name="CryptoCurrencyAuto">Авто</string>
     <string name="CryptoCurrencyAed">Дирхам ОАЭ</string>

--- a/TMessagesProj/src/main/res/values/strings_oe_pill.xml
+++ b/TMessagesProj/src/main/res/values/strings_oe_pill.xml
@@ -18,6 +18,13 @@
     <string name="PillStackProxy">Proxy</string>
     <string name="PillStackProxyPing">%1$d ms</string>
 
+    <string name="PillStackRam">RAM</string>
+    <string name="PillStackCpu">CPU</string>
+    <string name="PillStackNetSpeed">Internet Speed</string>
+    <string name="PillStackDcPing">DC Ping</string>
+    <string name="PillStackDcPingValue">%1$d ms</string>
+    <string name="PillStackGold">Gold</string>
+
     <string name="CryptoPillTargetCurrency">Target currency</string>
     <string name="CryptoCurrencyAuto">Auto</string>
     <string name="CryptoCurrencyAed">UAE Dirham</string>


### PR DESCRIPTION
Adds 7 new pills to the pill stack:
- RAM usage and CPU load (local telemetry)
- Network speed and DC ping
- Gold, ETH and EUR rates

Each pill has a toggle in settings and respects pill stack config/backup.